### PR TITLE
Redesign launcher for compact account rows and batch launching

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -28,17 +28,18 @@ Example | game.example.org | 9000
 **Edit Users** accepts one account per line:
 
 ```text
-myaccount | mypassword | Local, Example
+myaccount | mypassword
 anotheraccount | anotherpassword
 ```
 
-Omitting the server list associates the account with every configured server.
-Passwords are stored locally. A username with different passwords on different
-servers is exported as separate lines, preserving those credentials.
+Every user lists every configured server, including servers added later. Users
+can be added before any servers and survive removing all servers. Passwords are
+stored locally. Older conflicting passwords remain in Edit Users until you
+choose one password per username.
 Quote values containing separators or surrounding whitespace using JSON string
 escaping, for example `"password|with|separators"`.
 
-Removing a server association removes its saved characters. Keep names unchanged
+Removing a server removes its saved characters. Keep server names unchanged
 to retain their character settings. If profiles change while an editor is open,
 reopen the editor before saving.
 
@@ -58,8 +59,12 @@ continue to gate launching.
 ## Server status
 
 The launcher checks each configured endpoint every 30 seconds and on demand.
-**Online** means the game endpoint answered a status probe. **No response**
-means its availability is unknown; it does not prevent launching.
-Player counts come from TreeStats, matched by configured server name. Missing
+A green dot means the game endpoint answered; a red dot means no response
+within the timeout (offline or unreachable). Gray means not checked yet.
+Status does not prevent launching. Player counts come from TreeStats, matched
+by server name or an unambiguous hostname label such as coldeve in play.coldeve.ac. Missing
 counts are shown as unavailable and failed refreshes mark cached counts stale.
 These external population counts are separate from endpoint reachability.
+
+Failed launches stay visible on their account/server row. Play refreshes when
+the reconnect delay expires, even if no further session event arrives.

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -1,0 +1,65 @@
+# OpenAC launcher
+
+The launcher groups accounts by username. Expand an account to see its servers.
+Resize the window to fit your desktop; the account list scrolls independently
+of the launch controls.
+
+Choose **Character select** or a known character, then **Graphical** or
+**Headless**. Headless sessions need a named character. Check server rows and
+choose **Play selected** to start all eligible selections. Each row starts a
+separate supervised session. A failed launch is reported without preventing
+the other selected rows from starting. Already active accounts cannot start
+again on the same server. **Cancel** stops pending starts; use the row's
+**Stop** action to close an active session gracefully.
+
+## Users and servers
+
+The bottom editors run inside the launcher on Windows and Linux. Saves are
+validated and atomic; malformed text does not partially change your profiles.
+Close active sessions before saving profile edits.
+
+**Edit Servers** accepts one server per line:
+
+```text
+Local | 127.0.0.1 | 9000
+Example | game.example.org | 9000
+```
+
+**Edit Users** accepts one account per line:
+
+```text
+myaccount | mypassword | Local, Example
+anotheraccount | anotherpassword
+```
+
+Omitting the server list associates the account with every configured server.
+Passwords are stored locally. A username with different passwords on different
+servers is exported as separate lines, preserving those credentials.
+Quote values containing separators or surrounding whitespace using JSON string
+escaping, for example `"password|with|separators"`.
+
+Removing a server association removes its saved characters. Keep names unchanged
+to retain their character settings. If profiles change while an editor is open,
+reopen the editor before saving.
+
+Use a named character row's **…** action for plugins and one-command-per-line
+logon commands. **Logon commands** in the bottom bar provides the complete
+structured command list for bulk editing.
+
+## Installation and updates
+
+First setup opens when required. **Installation & updates** always provides
+setup, file verification and a manual update check. Available updates appear
+above the accounts; **Review update** opens the existing verified updater.
+Close active sessions before installing. Long content preparation retains its
+progress and cancellation controls. Content and client compatibility checks
+continue to gate launching.
+
+## Server status
+
+The launcher checks each configured endpoint every 30 seconds and on demand.
+**Online** means the game endpoint answered a status probe. **No response**
+means its availability is unknown; it does not prevent launching.
+Player counts come from TreeStats, matched by configured server name. Missing
+counts are shown as unavailable and failed refreshes mark cached counts stale.
+These external population counts are separate from endpoint reachability.

--- a/src/AcDream.Launcher.Core/Installation/LauncherInstaller.cs
+++ b/src/AcDream.Launcher.Core/Installation/LauncherInstaller.cs
@@ -459,7 +459,7 @@ public sealed class LauncherInstaller : ILauncherInstaller
             if (!File.Exists(bakeOutputPath))
             {
                 throw new LauncherInstallException(
-                    "The bake tool reported success but did not publish acdream.pak.");
+                    "The bake tool reported success but did not publish the prepared game data.");
             }
 
             long size = new FileInfo(bakeOutputPath).Length;

--- a/src/AcDream.Launcher.Core/Launching/BoundedProcessOutputCapture.cs
+++ b/src/AcDream.Launcher.Core/Launching/BoundedProcessOutputCapture.cs
@@ -145,7 +145,7 @@ public sealed class BoundedProcessOutputCapture : IDisposable
         try
         {
             byte[] marker = Encoding.UTF8.GetBytes(
-                $"\n[acdream-launcher] client.err.log truncated at {_maxBytes} bytes\n");
+                $"\n[OpenAC launcher] client.err.log truncated at {_maxBytes} bytes\n");
             WriteChunkLocked(marker);
         }
         catch (Exception error) when (IsRecoverableIoFailure(error))

--- a/src/AcDream.Launcher.Core/Orchestration/ILauncherOrchestrator.cs
+++ b/src/AcDream.Launcher.Core/Orchestration/ILauncherOrchestrator.cs
@@ -9,6 +9,12 @@ public interface ILauncherOrchestrator : IDisposable
 
     void LoadProfiles();
 
+    string ReadProfileText(LauncherTextEditorKind kind) =>
+        throw new NotSupportedException("Text editing is not available.");
+
+    void SaveProfileText(LauncherTextEditorKind kind, string text, string originalText) =>
+        throw new NotSupportedException("Text editing is not available.");
+
     LauncherStateSnapshot GetSnapshot();
 
     LauncherCapability GetLaunchCapability(LaunchMode mode);

--- a/src/AcDream.Launcher.Core/Orchestration/LauncherOrchestrator.cs
+++ b/src/AcDream.Launcher.Core/Orchestration/LauncherOrchestrator.cs
@@ -67,6 +67,7 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
         {
             ThrowIfDisposed();
             _profileStore.Load();
+            LauncherProfileText.EnableSharedUsers(_profileStore.Document);
         }
 
         RaiseStateChanged();
@@ -91,7 +92,8 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
                 sessions,
                 _platform,
                 _installRecord is not null,
-                _installationStatus);
+                _installationStatus,
+                _profileStore.Document.Users?.Select(user => user.Account).ToArray());
         }
     }
 
@@ -292,6 +294,8 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
         MutateProfiles(() =>
         {
             EnsureAccountIdleLocked(serverName, accountName);
+            if (_profileStore.Document.Users is not null)
+                foreach (var server in _profileStore.Document.Servers) EnsureAccountIdleLocked(server.Name, accountName);
             _profileStore.EditAccount(
                 serverName,
                 accountName,
@@ -303,6 +307,8 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
         MutateProfiles(() =>
         {
             EnsureAccountIdleLocked(serverName, accountName);
+            if (_profileStore.Document.Users is not null)
+                foreach (var server in _profileStore.Document.Servers) EnsureAccountIdleLocked(server.Name, accountName);
             _profileStore.RemoveAccount(serverName, accountName);
         });
 
@@ -731,6 +737,7 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
                 request.Activity.Supervisor = supervisor;
                 request.Activity.SupervisorStateHandler = stateHandler;
                 request.Activity.StatusSource = statusSource;
+                request.Activity.StderrLogPath = composed.StderrLogPath;
                 request.Activity.Status = "Starting host process…";
             }
 
@@ -839,6 +846,7 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
                         break;
                     case LauncherSessionState.Exited:
                         activity.ExitCode ??= activity.Supervisor?.ExitCode;
+                        if (activity.ExitCode is not null and not 0) activity.Error ??= ReadStartupFailure(activity);
                         if (!activity.IsTerminal)
                         {
                             activity.State = LauncherActivityState.Exited;
@@ -957,6 +965,7 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
                     activity.ExitCode = exited.Code;
                     activity.HostReportedExit = true;
                     activity.ExitReason = exited.Reason;
+                    if (exited.Code != 0) activity.Error ??= ReadStartupFailure(activity);
                     activity.HostTerminalStatus =
                         $"Exited: {exited.Reason} (code {exited.Code}).";
                     activity.Status = activity.HostTerminalStatus;
@@ -1075,6 +1084,24 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
             characters,
             active is not null,
             active?.Status ?? "Idle");
+    }
+
+    private static string ReadStartupFailure(ManagedActivity activity)
+    {
+        try
+        {
+            if (activity.StderrLogPath is { } path && File.Exists(path))
+            {
+                using var reader = new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+                char[] buffer = new char[4096];
+                string text = new(buffer, 0, reader.ReadBlock(buffer, 0, buffer.Length));
+                if (text.Contains("bake tool", StringComparison.Ordinal) && text.Contains("does not match", StringComparison.Ordinal))
+                    return "The installed client and prepared game files are different versions. Update the client to match your game files before trying again.";
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+        return $"Client exited with code {activity.ExitCode}. See the session log for details.";
     }
 
     private void MutateProfiles(Action mutation)
@@ -1345,6 +1372,7 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
         public int? ExitCode { get; set; }
 
         public string? Error { get; set; }
+        public string? StderrLogPath { get; set; }
 
         public string? HostTerminalStatus { get; set; }
 

--- a/src/AcDream.Launcher.Core/Orchestration/LauncherOrchestrator.cs
+++ b/src/AcDream.Launcher.Core/Orchestration/LauncherOrchestrator.cs
@@ -243,6 +243,25 @@ public sealed class LauncherOrchestrator : ILauncherOrchestrator
     public void AddServer(string name, string host, int port) =>
         MutateProfiles(() => _profileStore.AddServer(name, host, port));
 
+    public string ReadProfileText(LauncherTextEditorKind kind)
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            return LauncherProfileText.Read(_profileStore.Document, kind);
+        }
+    }
+
+    public void SaveProfileText(LauncherTextEditorKind kind, string text, string originalText) =>
+        MutateProfiles(() =>
+        {
+            if (!string.Equals(LauncherProfileText.Read(_profileStore.Document, kind), originalText, StringComparison.Ordinal))
+                throw new LauncherProfileException("Profiles changed while this editor was open. Close and reopen it before saving.");
+            foreach (var server in _profileStore.Document.Servers)
+                EnsureServerIdleLocked(server.Name);
+            LauncherProfileText.Apply(_profileStore.Document, kind, text);
+        });
+
     public void EditServer(string name, string newName, string newHost, int newPort) =>
         MutateProfiles(() =>
         {

--- a/src/AcDream.Launcher.Core/Orchestration/LauncherStateSnapshot.cs
+++ b/src/AcDream.Launcher.Core/Orchestration/LauncherStateSnapshot.cs
@@ -71,7 +71,8 @@ public sealed record LauncherStateSnapshot(
     IReadOnlyList<LauncherSessionSnapshot> Sessions,
     LauncherPlatformCapabilities Platform,
     bool IsInstallationReady,
-    string InstallationStatus);
+    string InstallationStatus,
+    IReadOnlyList<string>? SharedAccountNames = null);
 
 public sealed class LauncherOperationException : Exception
 {

--- a/src/AcDream.Launcher.Core/Profiles/LauncherProfileDocument.cs
+++ b/src/AcDream.Launcher.Core/Profiles/LauncherProfileDocument.cs
@@ -8,4 +8,9 @@ public sealed class LauncherProfileDocument
     public int Version { get; set; } = LauncherProfileStore.CurrentVersion;
 
     public List<ServerProfile> Servers { get; set; } = [];
+
+    // Null identifies documents created before the shared user list was introduced.
+    public List<LauncherUser>? Users { get; set; }
 }
+
+public sealed record LauncherUser(string Account, string Password);

--- a/src/AcDream.Launcher.Core/Profiles/LauncherProfileStore.cs
+++ b/src/AcDream.Launcher.Core/Profiles/LauncherProfileStore.cs
@@ -86,6 +86,7 @@ public sealed class LauncherProfileStore
         }
 
         ValidateAndNormalizeDocument(document);
+        LauncherProfileText.SynchronizeUsers(document);
         Document = document;
         return true;
     }
@@ -178,6 +179,7 @@ public sealed class LauncherProfileStore
 
         var server = new ServerProfile { Name = name, Host = host, Port = port };
         Document.Servers.Add(server);
+        LauncherProfileText.SynchronizeUsers(Document);
         return server;
     }
 
@@ -236,6 +238,11 @@ public sealed class LauncherProfileStore
 
         var profile = new AccountProfile { Account = account, Password = password };
         server.Accounts.Add(profile);
+        if (Document.Users is { } users)
+        {
+            users.Add(new LauncherUser(account, password));
+            LauncherProfileText.SynchronizeUsers(Document);
+        }
         return profile;
     }
 
@@ -265,6 +272,14 @@ public sealed class LauncherProfileStore
         {
             profile.Password = newPassword;
         }
+        if (Document.Users is { } users)
+        {
+            int index = users.FindIndex(user => user.Account == account);
+            users[index] = new LauncherUser(profile.Account, profile.Password);
+            foreach (var other in Document.Servers.SelectMany(item => item.Accounts).Where(item => item.Account == account))
+                other.Account = profile.Account;
+            LauncherProfileText.SynchronizeUsers(Document);
+        }
     }
 
     public void RemoveAccount(string serverName, string account)
@@ -272,6 +287,11 @@ public sealed class LauncherProfileStore
         ServerProfile server = FindServerOrThrow(serverName);
         AccountProfile profile = FindAccountOrThrow(server, account);
         server.Accounts.Remove(profile);
+        if (Document.Users is { } users)
+        {
+            users.RemoveAll(user => user.Account == account);
+            LauncherProfileText.SynchronizeUsers(Document);
+        }
     }
 
 
@@ -424,6 +444,7 @@ public sealed class LauncherProfileStore
         {
             mutation();
             ValidateAndNormalizeDocument(Document);
+            LauncherProfileText.SynchronizeUsers(Document);
             Save();
         }
         catch
@@ -580,6 +601,7 @@ public sealed class LauncherProfileStore
         new()
         {
             Version = source.Version,
+            Users = source.Users?.ToList(),
             Servers = source.Servers.Select(server => new ServerProfile
             {
                 Name = server.Name,

--- a/src/AcDream.Launcher.Core/Profiles/LauncherProfileText.cs
+++ b/src/AcDream.Launcher.Core/Profiles/LauncherProfileText.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AcDream.Launcher.Core.Profiles;
+
+public enum LauncherTextEditorKind { Users, Servers, LogonCommands }
+
+/// <summary>Editable projections over the canonical profile document.</summary>
+public static class LauncherProfileText
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
+
+    public static string Read(LauncherProfileDocument document, LauncherTextEditorKind kind) => kind switch
+    {
+        LauncherTextEditorKind.Users => string.Join(Environment.NewLine, document.Servers
+            .SelectMany(s => s.Accounts.Select(a => (Server: s.Name, Account: a)))
+            .GroupBy(x => (x.Account.Account, x.Account.Password))
+            .Select(g => $"{Encode(g.Key.Account)} | {Encode(g.Key.Password)} | {string.Join(", ", g.Select(x => Encode(x.Server)))}")),
+        LauncherTextEditorKind.Servers => string.Join(Environment.NewLine, document.Servers
+            .Select(s => $"{Encode(s.Name)} | {Encode(s.Host)} | {s.Port}")),
+        LauncherTextEditorKind.LogonCommands => JsonSerializer.Serialize(document.Servers
+            .SelectMany(s => s.Accounts.SelectMany(a => a.Characters.Select(c =>
+                new CommandEntry(s.Name, a.Account, c.Name, c.LoginCommands.ToArray())))), Options),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+    };
+
+    public static void Apply(LauncherProfileDocument document, LauncherTextEditorKind kind, string text)
+    {
+        switch (kind)
+        {
+            case LauncherTextEditorKind.Users:
+                var users = Lines(text).Select(line =>
+                {
+                    var fields = SplitFields(line, '|');
+                    Require(fields.Length is 2 or 3, "Each user line must be username | password | server1, server2. The server list may be omitted.");
+                    return new UserEntry(Decode(fields[0]), Decode(fields[1]),
+                        fields.Length == 2 || string.IsNullOrWhiteSpace(fields[2])
+                            ? document.Servers.Select(s => s.Name).ToArray()
+                            : SplitFields(fields[2], ',').Select(Decode).ToArray());
+                }).ToArray();
+                var replacements = document.Servers.ToDictionary(s => s.Name, _ => new List<AccountProfile>(), StringComparer.Ordinal);
+                foreach (var user in users)
+                {
+                    Require(!string.IsNullOrWhiteSpace(user.Username) && user.Password is not null && user.Servers is { Length: > 0 }, "Each user needs a username, password and at least one server.");
+                    foreach (string name in user.Servers)
+                    {
+                        Require(name is not null && replacements.ContainsKey(name), "A user refers to an unknown server. Add it in Edit Servers first.");
+                        var accounts = replacements[name];
+                        Require(!accounts.Any(a => a.Account == user.Username), "An account may appear only once on each server.");
+                        var existing = document.Servers.Single(s => s.Name == name).Accounts.Find(a => a.Account == user.Username);
+                        accounts.Add(new AccountProfile { Account = user.Username, Password = user.Password, Characters = existing?.Characters ?? [] });
+                    }
+                }
+                foreach (var server in document.Servers) server.Accounts = replacements[server.Name];
+                break;
+            case LauncherTextEditorKind.Servers:
+                var servers = Lines(text).Select(line =>
+                {
+                    var fields = SplitFields(line, '|');
+                    Require(fields.Length == 3, "Each server line must be name | host | port.");
+                    Require(int.TryParse(Decode(fields[2]), out int port), "Server ports must be numbers from 1 to 65535.");
+                    return new ServerEntry(Decode(fields[0]), Decode(fields[1]), port);
+                }).ToArray();
+                Require(servers.All(s => !string.IsNullOrWhiteSpace(s.Name) && !string.IsNullOrWhiteSpace(s.Host) && s.Port is >= 1 and <= 65535), "Each server needs a name, host and port from 1 to 65535.");
+                Require(servers.Select(s => s.Name).Distinct(StringComparer.Ordinal).Count() == servers.Length, "Server names must be unique.");
+                document.Servers = servers.Select(s => new ServerProfile { Name = s.Name, Host = s.Host, Port = s.Port,
+                    Accounts = document.Servers.Find(old => old.Name == s.Name)?.Accounts ?? [] }).ToList();
+                break;
+            case LauncherTextEditorKind.LogonCommands:
+                var entries = Parse<CommandEntry>(text);
+                var changes = new Dictionary<CharacterProfile, string[]>();
+                foreach (var entry in entries)
+                {
+                    var character = document.Servers.Find(s => s.Name == entry.Server)?.Accounts.Find(a => a.Account == entry.Account)?.Characters.Find(c => c.Name == entry.Character);
+                    Require(character is not null, "A command entry refers to an unknown server, account or character.");
+                    Require(entry.Commands is not null && entry.Commands.All(c => !string.IsNullOrWhiteSpace(c)), "Commands must be nonempty strings. Use [] for no commands.");
+                    Require(changes.TryAdd(character!, entry.Commands), "Each character may appear only once.");
+                }
+                foreach (var server in document.Servers)
+                    foreach (var account in server.Accounts)
+                        foreach (var character in account.Characters)
+                            character.LoginCommands = changes.TryGetValue(character, out var commands) ? commands.ToList() : [];
+                break;
+            default: throw new ArgumentOutOfRangeException(nameof(kind));
+        }
+    }
+
+    private static IEnumerable<string> Lines(string text) => text.Split('\n')
+        .Select(line => line.Trim()).Where(line => line.Length > 0);
+
+    private static string Encode(string value) => value != value.Trim() || value.IndexOfAny(['|', ',', '"', '\r', '\n', '\t']) >= 0
+        ? JsonSerializer.Serialize(value) : value;
+
+    private static string Decode(string field)
+    {
+        field = field.Trim();
+        if (!field.Contains('"')) return field;
+        try
+        {
+            Require(field.StartsWith('"'), "A quoted field must use double quotes around the entire value.");
+            return JsonSerializer.Deserialize<string>(field) ?? "";
+        }
+        catch (JsonException) { throw new LauncherProfileException("Invalid quoted field. Use double quotes around values containing separators; escape quotes as \\\" and backslashes as \\\\. "); }
+    }
+
+    private static string[] SplitFields(string line, char separator)
+    {
+        var fields = new List<string>();
+        bool quoted = false;
+        bool escaped = false;
+        int start = 0;
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (quoted && escaped) { escaped = false; continue; }
+            if (quoted && c == '\\') { escaped = true; continue; }
+            if (c == '"') { quoted = !quoted; continue; }
+            if (!quoted && c == separator) { fields.Add(line[start..i]); start = i + 1; }
+        }
+        Require(!quoted, "A quoted field is missing its closing double quote.");
+        fields.Add(line[start..]);
+        return fields.ToArray();
+    }
+
+    private static T[] Parse<T>(string text) where T : class
+    {
+        try
+        {
+            var values = JsonSerializer.Deserialize<T[]>(text, Options);
+            Require(values is not null && values.All(v => v is not null), "Enter a JSON array of entries; use [] for an empty list.");
+            return values!;
+        }
+        catch (JsonException) { throw new LauncherProfileException("Invalid JSON. Check field names, quotes, commas and brackets."); }
+    }
+
+    private static void Require([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] bool condition, string message)
+    {
+        if (!condition) throw new LauncherProfileException(message);
+    }
+
+    private sealed record UserEntry(string Username, string Password, string[] Servers);
+    private sealed record ServerEntry(string Name, string Host, int Port);
+    private sealed record CommandEntry(string Server, string Account, string Character, string[] Commands);
+}

--- a/src/AcDream.Launcher.Core/Profiles/LauncherProfileText.cs
+++ b/src/AcDream.Launcher.Core/Profiles/LauncherProfileText.cs
@@ -17,10 +17,8 @@ public static class LauncherProfileText
 
     public static string Read(LauncherProfileDocument document, LauncherTextEditorKind kind) => kind switch
     {
-        LauncherTextEditorKind.Users => string.Join(Environment.NewLine, document.Servers
-            .SelectMany(s => s.Accounts.Select(a => (Server: s.Name, Account: a)))
-            .GroupBy(x => (x.Account.Account, x.Account.Password))
-            .Select(g => $"{Encode(g.Key.Account)} | {Encode(g.Key.Password)} | {string.Join(", ", g.Select(x => Encode(x.Server)))}")),
+        LauncherTextEditorKind.Users => string.Join(Environment.NewLine, GetUsers(document)
+            .Select(user => $"{Encode(user.Account)} | {Encode(user.Password)}")),
         LauncherTextEditorKind.Servers => string.Join(Environment.NewLine, document.Servers
             .Select(s => $"{Encode(s.Name)} | {Encode(s.Host)} | {s.Port}")),
         LauncherTextEditorKind.LogonCommands => JsonSerializer.Serialize(document.Servers
@@ -37,26 +35,14 @@ public static class LauncherProfileText
                 var users = Lines(text).Select(line =>
                 {
                     var fields = SplitFields(line, '|');
-                    Require(fields.Length is 2 or 3, "Each user line must be username | password | server1, server2. The server list may be omitted.");
-                    return new UserEntry(Decode(fields[0]), Decode(fields[1]),
-                        fields.Length == 2 || string.IsNullOrWhiteSpace(fields[2])
-                            ? document.Servers.Select(s => s.Name).ToArray()
-                            : SplitFields(fields[2], ',').Select(Decode).ToArray());
-                }).ToArray();
-                var replacements = document.Servers.ToDictionary(s => s.Name, _ => new List<AccountProfile>(), StringComparer.Ordinal);
-                foreach (var user in users)
-                {
-                    Require(!string.IsNullOrWhiteSpace(user.Username) && user.Password is not null && user.Servers is { Length: > 0 }, "Each user needs a username, password and at least one server.");
-                    foreach (string name in user.Servers)
-                    {
-                        Require(name is not null && replacements.ContainsKey(name), "A user refers to an unknown server. Add it in Edit Servers first.");
-                        var accounts = replacements[name];
-                        Require(!accounts.Any(a => a.Account == user.Username), "An account may appear only once on each server.");
-                        var existing = document.Servers.Single(s => s.Name == name).Accounts.Find(a => a.Account == user.Username);
-                        accounts.Add(new AccountProfile { Account = user.Username, Password = user.Password, Characters = existing?.Characters ?? [] });
-                    }
-                }
-                foreach (var server in document.Servers) server.Accounts = replacements[server.Name];
+                    Require(fields.Length == 2, "Each user line must be username | password.");
+                    return new LauncherUser(Decode(fields[0]), Decode(fields[1]));
+                }).ToList();
+                Require(users.All(user => !string.IsNullOrWhiteSpace(user.Account)), "Each user needs a username.");
+                Require(users.Select(user => user.Account).Distinct(StringComparer.Ordinal).Count() == users.Count,
+                    "Each username must appear once. All servers use the same password for that user.");
+                document.Users = users;
+                SynchronizeUsers(document);
                 break;
             case LauncherTextEditorKind.Servers:
                 var servers = Lines(text).Select(line =>
@@ -68,8 +54,10 @@ public static class LauncherProfileText
                 }).ToArray();
                 Require(servers.All(s => !string.IsNullOrWhiteSpace(s.Name) && !string.IsNullOrWhiteSpace(s.Host) && s.Port is >= 1 and <= 65535), "Each server needs a name, host and port from 1 to 65535.");
                 Require(servers.Select(s => s.Name).Distinct(StringComparer.Ordinal).Count() == servers.Length, "Server names must be unique.");
+                document.Users ??= GetUsers(document).ToList();
                 document.Servers = servers.Select(s => new ServerProfile { Name = s.Name, Host = s.Host, Port = s.Port,
                     Accounts = document.Servers.Find(old => old.Name == s.Name)?.Accounts ?? [] }).ToList();
+                SynchronizeUsers(document);
                 break;
             case LauncherTextEditorKind.LogonCommands:
                 var entries = Parse<CommandEntry>(text);
@@ -88,6 +76,34 @@ public static class LauncherProfileText
                 break;
             default: throw new ArgumentOutOfRangeException(nameof(kind));
         }
+    }
+
+    private static IEnumerable<LauncherUser> GetUsers(LauncherProfileDocument document) =>
+        document.Users ?? document.Servers.SelectMany(server => server.Accounts)
+            .Select(account => new LauncherUser(account.Account, account.Password)).Distinct().ToList();
+
+    internal static void SynchronizeUsers(LauncherProfileDocument document)
+    {
+        if (document.Users is not { } users) return;
+        Require(users.All(user => user is not null && !string.IsNullOrWhiteSpace(user.Account) && user.Password is not null),
+            "Each user needs a username and password field.");
+        Require(users.Select(user => user.Account).Distinct(StringComparer.Ordinal).Count() == users.Count,
+            "Each username must appear once. Resolve its passwords in Edit Users first.");
+        foreach (var server in document.Servers)
+            server.Accounts = users.Select(user => new AccountProfile
+            {
+                Account = user.Account, Password = user.Password,
+                Characters = server.Accounts.Find(account => account.Account == user.Account)?.Characters ?? [],
+            }).ToList();
+    }
+
+    internal static void EnableSharedUsers(LauncherProfileDocument document)
+    {
+        var users = GetUsers(document).ToList();
+        // Keep conflicting older credentials available in the editor for explicit resolution.
+        if (users.Select(user => user.Account).Distinct(StringComparer.Ordinal).Count() != users.Count) return;
+        document.Users = users;
+        SynchronizeUsers(document);
     }
 
     private static IEnumerable<string> Lines(string text) => text.Split('\n')
@@ -143,7 +159,7 @@ public static class LauncherProfileText
         if (!condition) throw new LauncherProfileException(message);
     }
 
-    private sealed record UserEntry(string Username, string Password, string[] Servers);
+
     private sealed record ServerEntry(string Name, string Host, int Port);
     private sealed record CommandEntry(string Server, string Account, string Character, string[] Commands);
 }

--- a/src/AcDream.Launcher.Core/Status/ServerHealthService.cs
+++ b/src/AcDream.Launcher.Core/Status/ServerHealthService.cs
@@ -1,0 +1,99 @@
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text.Json;
+
+namespace AcDream.Launcher.Core.Status;
+
+public sealed class ServerHealthService(
+    HttpClient httpClient,
+    IServerReachabilityProbe probe,
+    TimeProvider? timeProvider = null) : IServerHealthService
+{
+    private static readonly Uri PopulationUri = new("https://treestats.net/player_counts-latest.json");
+    private readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    private readonly SemaphoreSlim _populationGate = new(1, 1);
+    private Dictionary<string, int> _counts = new(StringComparer.OrdinalIgnoreCase);
+    private DateTimeOffset? _lastAttempt;
+    private DateTimeOffset? _lastSuccess;
+
+    public async Task<ServerHealthSnapshot> CheckAsync(string host, int port, string serverName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serverName);
+        ArgumentOutOfRangeException.ThrowIfLessThan(port, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535);
+        Task<double?> reachability = CheckReachabilityAsync(host, port, cancellationToken);
+        var populationTask = GetPopulationAsync(serverName, cancellationToken);
+        await Task.WhenAll(reachability, populationTask).ConfigureAwait(false);
+        var population = await populationTask.ConfigureAwait(false);
+        double? latency = await reachability.ConfigureAwait(false);
+        return new(latency.HasValue ? true : null, latency, population.Count,
+            population.Stale, _time.GetUtcNow());
+    }
+
+    private async Task<double?> CheckReachabilityAsync(string host, int port, CancellationToken token)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(token);
+        timeout.CancelAfter(TimeSpan.FromSeconds(3));
+        try
+        {
+            return await probe.ProbeAsync(host, port, timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!token.IsCancellationRequested) { return null; }
+        catch (SocketException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private async Task<(int? Count, bool Stale)> GetPopulationAsync(string serverName, CancellationToken token)
+    {
+        await _populationGate.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            var now = _time.GetUtcNow();
+            if (_lastAttempt is null || now - _lastAttempt >= TimeSpan.FromMinutes(1))
+            {
+                _lastAttempt = now;
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(token);
+                timeout.CancelAfter(TimeSpan.FromSeconds(5));
+                try
+                {
+                    using var response = await httpClient.GetAsync(PopulationUri,
+                        HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+                    response.EnsureSuccessStatusCode();
+                    await response.Content.LoadIntoBufferAsync(1_048_576, timeout.Token).ConfigureAwait(false);
+                    _counts = ParsePlayerCounts(await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false));
+                    _lastSuccess = _time.GetUtcNow();
+                }
+                catch (OperationCanceledException) when (!token.IsCancellationRequested) { }
+                catch (HttpRequestException) { }
+                catch (JsonException) { }
+                catch (IOException) { }
+            }
+            int? count = _counts.TryGetValue(serverName.Trim(), out var value) ? value : null;
+            bool stale = count.HasValue && (_lastSuccess is null || _lastAttempt > _lastSuccess
+                || _time.GetUtcNow() - _lastSuccess > TimeSpan.FromMinutes(5));
+            return (count, stale);
+        }
+        finally { _populationGate.Release(); }
+    }
+
+    internal static Dictionary<string, int> ParsePlayerCounts(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+            throw new JsonException("Expected a population list.");
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in document.RootElement.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object
+                || !item.TryGetProperty("server", out var name) || name.ValueKind != JsonValueKind.String
+                || string.IsNullOrWhiteSpace(name.GetString())
+                || !item.TryGetProperty("count", out var count) || count.ValueKind != JsonValueKind.Number
+                || !count.TryGetInt32(out var value) || value < 0)
+                continue;
+            counts[name.GetString()!.Trim()] = value;
+        }
+        return counts;
+    }
+}

--- a/src/AcDream.Launcher.Core/Status/ServerHealthService.cs
+++ b/src/AcDream.Launcher.Core/Status/ServerHealthService.cs
@@ -24,11 +24,11 @@ public sealed class ServerHealthService(
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535);
         Task<double?> reachability = CheckReachabilityAsync(host, port, cancellationToken);
-        var populationTask = GetPopulationAsync(serverName, cancellationToken);
+        var populationTask = GetPopulationAsync(serverName, host, cancellationToken);
         await Task.WhenAll(reachability, populationTask).ConfigureAwait(false);
         var population = await populationTask.ConfigureAwait(false);
         double? latency = await reachability.ConfigureAwait(false);
-        return new(latency.HasValue ? true : null, latency, population.Count,
+        return new(latency.HasValue, latency, population.Count,
             population.Stale, _time.GetUtcNow());
     }
 
@@ -45,7 +45,7 @@ public sealed class ServerHealthService(
         catch (IOException) { return null; }
     }
 
-    private async Task<(int? Count, bool Stale)> GetPopulationAsync(string serverName, CancellationToken token)
+    private async Task<(int? Count, bool Stale)> GetPopulationAsync(string serverName, string host, CancellationToken token)
     {
         await _populationGate.WaitAsync(token).ConfigureAwait(false);
         try
@@ -70,12 +70,23 @@ public sealed class ServerHealthService(
                 catch (JsonException) { }
                 catch (IOException) { }
             }
-            int? count = _counts.TryGetValue(serverName.Trim(), out var value) ? value : null;
+            int? count = FindPlayerCount(_counts, serverName, host);
             bool stale = count.HasValue && (_lastSuccess is null || _lastAttempt > _lastSuccess
                 || _time.GetUtcNow() - _lastSuccess > TimeSpan.FromMinutes(5));
             return (count, stale);
         }
         finally { _populationGate.Release(); }
+    }
+
+    internal static int? FindPlayerCount(IReadOnlyDictionary<string, int> counts, string serverName, string host)
+    {
+        if (counts.TryGetValue(serverName.Trim(), out int value)) return value;
+        static string Normalize(string name) => new(name.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+        string label = Normalize(serverName);
+        string[] hostParts = host.TrimEnd('.').Split('.').Select(Normalize).ToArray();
+        var matches = counts.Where(pair => Normalize(pair.Key) == label
+            || hostParts.Contains(Normalize(pair.Key), StringComparer.Ordinal)).ToArray();
+        return matches.Length == 1 ? matches[0].Value : null;
     }
 
     internal static Dictionary<string, int> ParsePlayerCounts(string json)

--- a/src/AcDream.Launcher.Core/Status/ServerHealthSnapshot.cs
+++ b/src/AcDream.Launcher.Core/Status/ServerHealthSnapshot.cs
@@ -1,0 +1,19 @@
+namespace AcDream.Launcher.Core.Status;
+
+public sealed record ServerHealthSnapshot(
+    bool? IsReachable,
+    double? LatencyMilliseconds,
+    int? PlayerCount,
+    bool IsPlayerCountStale,
+    DateTimeOffset CheckedAt);
+
+public interface IServerHealthService
+{
+    Task<ServerHealthSnapshot> CheckAsync(string host, int port, string serverName,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IServerReachabilityProbe
+{
+    Task<double?> ProbeAsync(string host, int port, CancellationToken cancellationToken);
+}

--- a/src/AcDream.Launcher.Core/Status/UdpServerReachabilityProbe.cs
+++ b/src/AcDream.Launcher.Core/Status/UdpServerReachabilityProbe.cs
@@ -1,0 +1,48 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace AcDream.Launcher.Core.Status;
+
+public sealed class UdpServerReachabilityProbe : IServerReachabilityProbe
+{
+    // The status identity is recognized without a password and never continues the handshake.
+    private static readonly byte[] Request = Convert.FromHexString(
+        "00000000000001009300D005000000004000000004003138303200003400000001000000000000003EB8A8581C006163736572766572747261636B65723A6A6A3968323668637367676300000000000000000000");
+
+    public async Task<double?> ProbeAsync(string host, int port, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(3));
+        var addresses = await Dns.GetHostAddressesAsync(host, timeout.Token).ConfigureAwait(false);
+        var address = addresses.FirstOrDefault(value => value.AddressFamily == AddressFamily.InterNetwork)
+            ?? addresses.FirstOrDefault();
+        if (address is null) return null;
+        using var client = new UdpClient(address.AddressFamily);
+        client.Connect(new IPEndPoint(address, port));
+        long started = Stopwatch.GetTimestamp();
+        await client.SendAsync(Request, timeout.Token).ConfigureAwait(false);
+        while (true)
+        {
+            var reply = await client.ReceiveAsync(timeout.Token).ConfigureAwait(false);
+            if (IsStatusReply(reply.Buffer))
+                return Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+        }
+    }
+
+    internal static bool IsStatusReply(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < 20) return false;
+        uint flags = BinaryPrimitives.ReadUInt32LittleEndian(packet[4..]);
+        int bodySize = BinaryPrimitives.ReadUInt16LittleEndian(packet[16..]);
+        if (bodySize != packet.Length - 20) return false;
+        // Accept the initial challenge or an explicit network rejection, not unrelated traffic.
+        return flags switch
+        {
+            0x00040000 => bodySize == 32,
+            0x00100000 or 0x00200000 => bodySize == 4,
+            _ => false,
+        };
+    }
+}

--- a/src/AcDream.Launcher.Core/Updates/LauncherSelfUpdateBootstrap.cs
+++ b/src/AcDream.Launcher.Core/Updates/LauncherSelfUpdateBootstrap.cs
@@ -467,7 +467,7 @@ public static class LauncherSelfUpdateBootstrap
         if (!PathsEqual(executable, expectedExecutable))
         {
             throw new LauncherUpdateException(
-                "Self-update can run only from the published acdream-launcher executable.");
+                "Self-update can run only from the published OpenAC launcher executable.");
         }
     }
 

--- a/src/AcDream.Launcher.Core/Updates/ReleaseManifestClient.cs
+++ b/src/AcDream.Launcher.Core/Updates/ReleaseManifestClient.cs
@@ -54,7 +54,7 @@ public sealed class ReleaseManifestClient : IReleaseManifestClient, IDisposable
         {
             Timeout = timeout ?? TimeSpan.FromSeconds(15),
         };
-        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acdream-launcher/1");
+        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("OpenAC-launcher/1");
     }
 
     internal static ReleaseManifestClient CreateLoopbackFixture(

--- a/src/AcDream.Launcher/AcDream.Launcher.csproj
+++ b/src/AcDream.Launcher/AcDream.Launcher.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <AssemblyName>acdream-launcher</AssemblyName>
+    <Title>OpenAC Launcher</Title>
+    <Product>OpenAC</Product>
+    <Description>OpenAC launcher, installer and updater</Description>
     <RootNamespace>AcDream.Launcher</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/AcDream.Launcher/App.axaml.cs
+++ b/src/AcDream.Launcher/App.axaml.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Net.Http;
+using AcDream.Launcher.Core.Status;
 using AcDream.Launcher.Core.Installation;
 using AcDream.Launcher.Core.Launching;
 using AcDream.Launcher.Core.Orchestration;
@@ -18,6 +20,7 @@ public sealed partial class App : Application
     private LauncherOrchestrator? _orchestrator;
     private LauncherWindowViewModel? _viewModel;
     private LauncherUpdateComposition? _updateComposition;
+    private readonly HttpClient _serverStatusClient = new();
 
     public App()
     {
@@ -92,6 +95,8 @@ public sealed partial class App : Application
                 DataContext = _viewModel,
             };
             desktop.MainWindow = mainWindow;
+            _viewModel.UpdatePrompt.AutoOpenDiscoveredUpdates = false;
+            _viewModel.ConfigureServerHealth(new ServerHealthService(_serverStatusClient, new UdpServerReachabilityProbe()));
             _viewModel.Initialize();
             mainWindow.Opened += OnMainWindowOpened;
             desktop.Exit += OnDesktopExit;
@@ -100,16 +105,20 @@ public sealed partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
-    private void OnMainWindowOpened(object? sender, EventArgs e)
+    private async void OnMainWindowOpened(object? sender, EventArgs e)
     {
         if (sender is MainWindow window)
         {
             window.Opened -= OnMainWindowOpened;
         }
 
-        if (_viewModel is not null)
+        if (_viewModel is { } viewModel)
         {
-            _ = _viewModel.StartBackgroundInitializationAsync();
+            await viewModel.StartBackgroundInitializationAsync();
+            if (ReferenceEquals(_viewModel, viewModel) && viewModel.IsFirstRunRequired)
+            {
+                viewModel.FirstRunWizardShell.OpenCommand.Execute(null);
+            }
         }
     }
 
@@ -118,6 +127,7 @@ public sealed partial class App : Application
         _viewModel?.Dispose();
         _orchestrator?.Dispose();
         _updateComposition?.Dispose();
+        _serverStatusClient.Dispose();
         _viewModel = null;
         _orchestrator = null;
         _updateComposition = null;

--- a/src/AcDream.Launcher/LauncherUpdateComposition.cs
+++ b/src/AcDream.Launcher/LauncherUpdateComposition.cs
@@ -75,7 +75,7 @@ internal sealed class LauncherUpdateComposition : IDisposable
             {
                 Timeout = TimeSpan.FromSeconds(15),
             };
-            artifactClient.DefaultRequestHeaders.UserAgent.ParseAdd("acdream-launcher/1");
+            artifactClient.DefaultRequestHeaders.UserAgent.ParseAdd("OpenAC-launcher/1");
             manifestClient = CreateManifestClient(manifestUri);
             var selfUpdates = new LauncherSelfUpdateManager(paths, artifactClient);
             var updater = new LauncherUpdater(

--- a/src/AcDream.Launcher/MainWindow.axaml
+++ b/src/AcDream.Launcher/MainWindow.axaml
@@ -84,10 +84,10 @@
                       <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:LauncherAccountServerRowViewModel">
                           <Border BorderBrush="#2B3941" BorderThickness="0,1,0,0" Padding="12,3,8,3">
-                            <Grid ColumnDefinitions="26,*,160,112,85,64,34" ColumnSpacing="6">
+                            <Grid ColumnDefinitions="26,*,160,112,85,64,34" RowDefinitions="Auto,Auto" ColumnSpacing="6">
                               <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" IsEnabled="{Binding CanEditSelection}" AutomationProperties.Name="Select account and server for batch launch" />
                               <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
-                                <TextBlock Text="{Binding ServerName}" TextTrimming="CharacterEllipsis" FontWeight="SemiBold" ToolTip.Tip="{Binding Endpoint}" />
+                                <Grid ColumnDefinitions="14,*"><Ellipse Width="7" Height="7" Fill="{Binding ServerDotColor}" ToolTip.Tip="{Binding ServerStatusText}" /><TextBlock Grid.Column="1" Text="{Binding ServerName}" TextTrimming="CharacterEllipsis" FontWeight="SemiBold" ToolTip.Tip="{Binding Endpoint}" /></Grid>
                                 <TextBlock Text="{Binding ServerStatusText}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" ToolTip.Tip="Status checks the game endpoint. Player counts are reported by TreeStats, matched by server name." />
                               </StackPanel>
                               <ComboBox Grid.Column="2" ItemsSource="{Binding CharacterChoices}" SelectedItem="{Binding SelectedCharacter, Mode=TwoWay}" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsEnabled="{Binding CanEditSelection}" AutomationProperties.Name="Character" />
@@ -96,6 +96,7 @@
                               <Button Grid.Column="5" Content="Play" Classes="primary" Command="{Binding PlayCommand}" IsVisible="{Binding !IsActive}" VerticalAlignment="Center" HorizontalAlignment="Stretch" ToolTip.Tip="{Binding DisabledReason}" />
                               <Button Grid.Column="5" Content="Stop" Command="{Binding StopCommand}" IsVisible="{Binding IsActive}" VerticalAlignment="Center" HorizontalAlignment="Stretch" />
                               <Button Grid.Column="6" Content="···" Padding="4" Command="{Binding OptionsCommand}" VerticalAlignment="Center" AutomationProperties.Name="Character options" />
+                              <TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="6" Text="{Binding LaunchError}" IsVisible="{Binding HasLaunchError}" Foreground="#FFB0A0" TextWrapping="Wrap" FontSize="12" Margin="0,3,0,3" />
                             </Grid>
                           </Border>
                         </DataTemplate>

--- a/src/AcDream.Launcher/MainWindow.axaml
+++ b/src/AcDream.Launcher/MainWindow.axaml
@@ -3,273 +3,140 @@
         xmlns:vm="using:AcDream.Launcher.ViewModels"
         x:Class="AcDream.Launcher.MainWindow"
         x:DataType="vm:LauncherWindowViewModel"
-        Title="acdream launcher"
+        Title="OpenAC"
         Icon="avares://acdream-launcher/Assets/acdream-launcher.png"
-        Width="1180"
-        Height="760"
-        MinWidth="900"
-        MinHeight="620"
-        Background="#10151D">
+        Width="1120" Height="740" MinWidth="760" MinHeight="460"
+        CanResize="True" Background="#10171C">
   <Window.Styles>
     <Style Selector="Border.card">
-      <Setter Property="Background" Value="#18212D" />
-      <Setter Property="CornerRadius" Value="8" />
+      <Setter Property="Background" Value="#1D2931" />
+      <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Padding" Value="16" />
     </Style>
+    <Style Selector="Button">
+      <Setter Property="Background" Value="#202C33" />
+      <Setter Property="BorderBrush" Value="#405059" />
+      <Setter Property="Padding" Value="10,5" />
+      <Setter Property="MinHeight" Value="28" />
+      <Setter Property="CornerRadius" Value="3" />
+    </Style>
     <Style Selector="Button.primary">
-      <Setter Property="Background" Value="#3C78D8" />
-      <Setter Property="Foreground" Value="White" />
+      <Setter Property="Background" Value="#DBB573" />
+      <Setter Property="Foreground" Value="#181A1B" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
-    <Style Selector="Button.danger">
-      <Setter Property="Background" Value="#8E3540" />
-      <Setter Property="Foreground" Value="White" />
+    <Style Selector="Button.primary:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="#E6C68F" />
+      <Setter Property="Foreground" Value="#181A1B" />
     </Style>
-    <Style Selector="TextBlock.muted">
-      <Setter Property="Foreground" Value="#A8B5C6" />
-    </Style>
-    <Style Selector="TextBlock.section">
-      <Setter Property="FontSize" Value="18" />
-      <Setter Property="FontWeight" Value="SemiBold" />
-    </Style>
+    <Style Selector="Button.danger"><Setter Property="Foreground" Value="#FFB0A0" /></Style>
+    <Style Selector="TextBlock.muted"><Setter Property="Foreground" Value="#A9BBC5" /></Style>
+    <Style Selector="TextBlock.section"><Setter Property="FontSize" Value="16" /><Setter Property="FontWeight" Value="SemiBold" /></Style>
+    <Style Selector="ComboBox"><Setter Property="MinHeight" Value="28" /><Setter Property="Padding" Value="6,3" /><Setter Property="Background" Value="#131D23" /></Style>
+    <Style Selector="CheckBox"><Setter Property="MinHeight" Value="24" /></Style>
+    <Style Selector="Expander"><Setter Property="Padding" Value="0" /><Setter Property="HorizontalContentAlignment" Value="Stretch" /></Style>
   </Window.Styles>
-
   <Grid RowDefinitions="Auto,Auto,*,Auto">
-    <Border Grid.Row="0" Background="#141C26" Padding="20,14">
-      <Grid ColumnDefinitions="*,Auto">
-        <StackPanel Spacing="2">
-          <TextBlock Text="acdream" FontSize="24" FontWeight="Bold" />
-          <TextBlock Text="Servers, accounts, characters, and supervised sessions"
-                     Classes="muted" />
-        </StackPanel>
-        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-          <Button Content="First-run setup"
-                  Command="{Binding FirstRunWizardShell.OpenCommand}" />
-          <Button Content="Verify files"
-                  AutomationProperties.Name="Verify installed client content"
-                  Command="{Binding VerifyContentCommand}" />
-        </StackPanel>
-      </Grid>
+    <Border Padding="18,10" Background="#152029">
+      <StackPanel Spacing="1">
+        <TextBlock Text="OpenAC" FontFamily="Georgia,serif" FontSize="27" Foreground="#DBB573" />
+        <TextBlock Text="Asheron's Call forever." FontFamily="Georgia,serif" FontSize="18" Foreground="#F0E4CD" />
+      </StackPanel>
     </Border>
-
-    <StackPanel Grid.Row="1" Margin="16,12,16,0" Spacing="8">
-      <Border Classes="card"
-              Padding="12"
-              Background="#4B3820"
-              IsVisible="{Binding ShowInstallationBanner}">
-        <Grid ColumnDefinitions="*,Auto">
-          <StackPanel Spacing="3">
-            <TextBlock Text="{Binding InstallationBannerTitle}" FontWeight="SemiBold" />
-            <TextBlock Text="{Binding InstallationStatus}" TextWrapping="Wrap" />
-          </StackPanel>
-          <Button Grid.Column="1"
-                  Content="Open setup"
-                  IsVisible="{Binding !IsInstallationChecking}"
-                  Command="{Binding FirstRunWizardShell.OpenCommand}" />
+    <StackPanel Grid.Row="1" Spacing="4">
+      <Border Background="#292820" Padding="14,8" IsVisible="{Binding ShowInstallationBanner}">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+          <StackPanel><TextBlock Text="{Binding InstallationBannerTitle}" FontWeight="SemiBold" /><TextBlock Text="{Binding InstallationStatus}" TextWrapping="Wrap" Classes="muted" /></StackPanel>
+          <Button Grid.Column="1" Content="Open setup" Classes="primary" IsVisible="{Binding !IsInstallationChecking}" Command="{Binding FirstRunWizardShell.OpenCommand}" />
         </Grid>
       </Border>
-      <Border Classes="card"
-              Padding="12"
-              Background="#24344B"
-              IsVisible="{Binding ShowGraphicalLaunchNotice}">
-        <StackPanel Spacing="3">
-          <TextBlock Text="Graphical launch unavailable" FontWeight="SemiBold" />
-          <TextBlock Text="{Binding GraphicalLaunchNotice}" TextWrapping="Wrap" />
-        </StackPanel>
+      <Border Background="#292820" Padding="14,8" IsVisible="{Binding ShowUpdateBanner}">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+          <StackPanel><TextBlock Text="An OpenAC update is available" FontWeight="SemiBold" /><TextBlock Text="{Binding UpdatePrompt.Body}" Classes="muted" TextWrapping="Wrap" /></StackPanel>
+          <Button Grid.Column="1" Content="Review update" Classes="primary" Command="{Binding ReviewUpdateCommand}" />
+        </Grid>
       </Border>
     </StackPanel>
-
-    <Grid Grid.Row="2" Margin="16" ColumnDefinitions="330,12,*" RowDefinitions="*,12,220">
-      <Border Grid.Column="0" Grid.RowSpan="3" Classes="card">
-        <Grid RowDefinitions="Auto,Auto,*,Auto">
-          <TextBlock Text="Profiles" Classes="section" />
-          <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6" Margin="0,12,0,10">
-            <Button Content="+ Server" Command="{Binding AddServerCommand}" />
-            <Button Content="+ Account" Command="{Binding AddAccountCommand}" />
-            <Button Content="+ Character" Command="{Binding AddCharacterCommand}" />
-          </StackPanel>
-          <TreeView x:Name="ProfilesTree"
-                    Grid.Row="2"
-                    ItemsSource="{Binding Servers}"
-                    SelectedItem="{Binding SelectedNode, Mode=TwoWay}">
-            <TreeView.DataTemplates>
-              <TreeDataTemplate DataType="{x:Type vm:LauncherTreeNodeViewModel}"
-                                ItemsSource="{Binding Children}">
-                <StackPanel Margin="2,4" Spacing="1">
-                  <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding SecondaryText}"
-                             Classes="muted"
-                             FontSize="11"
-                             TextTrimming="CharacterEllipsis" />
-                </StackPanel>
-              </TreeDataTemplate>
-            </TreeView.DataTemplates>
-          </TreeView>
-          <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
-            <Button Content="Edit" Command="{Binding EditSelectedCommand}" />
-            <Button Content="Remove"
-                    Classes="danger"
-                    Command="{Binding RemoveSelectedCommand}" />
-          </StackPanel>
-        </Grid>
-      </Border>
-
-      <Border Grid.Column="2" Grid.Row="0" Classes="card">
-        <ScrollViewer>
-          <StackPanel Spacing="14">
-            <StackPanel Spacing="3">
-              <TextBlock Text="{Binding SelectionTitle}" FontSize="24" FontWeight="Bold" />
-              <TextBlock Text="{Binding SelectionSubtitle}" Classes="muted" />
-            </StackPanel>
-
-            <Border Background="#213044" CornerRadius="6" Padding="12"
-                    IsVisible="{Binding IsServerSelected}">
-              <StackPanel Spacing="8">
-                <TextBlock Text="Server profile" Classes="section" />
-                <TextBlock Text="Add accounts beneath this server, or edit its host and port." TextWrapping="Wrap" />
-                <Button Content="Add account"
-                        HorizontalAlignment="Left"
-                        Command="{Binding AddAccountCommand}" />
-              </StackPanel>
-            </Border>
-
-            <Border Background="#213044" CornerRadius="6" Padding="12"
-                    IsVisible="{Binding IsAccountSelected}">
-              <StackPanel Spacing="8">
-                <TextBlock Text="Account profile" Classes="section" />
-                <TextBlock Text="Your characters appear here automatically after you log in."
-                           TextWrapping="Wrap" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                  <Button Content="Open character select"
-                          Classes="primary"
-                          AutomationProperties.Name="Open character select for account"
-                          Command="{Binding LaunchAccountGuiSelectCommand}" />
-                </StackPanel>
-                <TextBlock Text="{Binding AccountGuiSelectDisabledReason}"
-                           Classes="muted"
-                           TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-
-            <StackPanel IsVisible="{Binding IsCharacterSelected}" Spacing="14">
-              <Border Background="#213044" CornerRadius="6" Padding="12">
-                <StackPanel Spacing="10">
-                  <TextBlock Text="Launch" Classes="section" />
-                  <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button Content="Play"
-                            Classes="primary"
-                            MinWidth="110"
-                            AutomationProperties.Name="Play as the selected character"
-                            Command="{Binding LaunchGuiCommand}" />
-                    <Button Content="Headless"
-                            AutomationProperties.Name="Launch a headless session"
-                            Command="{Binding LaunchHeadlessCommand}" />
-                  </StackPanel>
-                  <TextBlock Text="{Binding GuiLaunchDisabledReason}"
-                             Classes="muted"
-                             TextWrapping="Wrap"
-                             IsVisible="{Binding ShowGuiLaunchDisabledReason}" />
-                  <TextBlock Text="{Binding HeadlessLaunchDisabledReason}"
-                             Classes="muted"
-                             TextWrapping="Wrap"
-                             IsVisible="{Binding ShowHeadlessLaunchDisabledReason}" />
-                </StackPanel>
-              </Border>
-
-              <Border Background="#213044" CornerRadius="6" Padding="12">
-                <StackPanel Spacing="10">
-                  <TextBlock Text="Per-character launch settings" Classes="section" />
-                  <Grid ColumnDefinitions="*,12,*">
-                    <StackPanel Spacing="5">
-                      <TextBlock Text="Plugins (one id per line — blank loads all, &quot;none&quot; disables)" Classes="muted" />
-                      <TextBox Text="{Binding CharacterPluginsText, Mode=TwoWay}"
-                               AcceptsReturn="True"
-                               TextWrapping="Wrap"
-                               MinHeight="96" />
-                    </StackPanel>
-                    <StackPanel Grid.Column="2" Spacing="5">
-                      <TextBlock Text="Login commands (ordered, one per line)" Classes="muted" />
-                      <TextBox Text="{Binding CharacterLoginCommandsText, Mode=TwoWay}"
-                               AcceptsReturn="True"
-                               TextWrapping="Wrap"
-                               MinHeight="96" />
-                    </StackPanel>
-                  </Grid>
-                  <Button Content="Save settings"
-                          HorizontalAlignment="Left"
-                          Command="{Binding SaveCharacterSettingsCommand}" />
-                </StackPanel>
-              </Border>
-            </StackPanel>
-          </StackPanel>
-        </ScrollViewer>
-      </Border>
-
-      <Border Grid.Column="2" Grid.Row="2" Classes="card">
-        <Grid RowDefinitions="Auto,Auto,*">
-          <Grid ColumnDefinitions="*,Auto">
-            <TextBlock Text="Sessions" Classes="section" />
-            <Button Grid.Column="1"
-                    Content="Clear finished"
-                    Command="{Binding ClearFinishedSessionsCommand}" />
-          </Grid>
-          <Grid Grid.Row="1"
-                ColumnDefinitions="2*,2*,130,3*,Auto"
-                Margin="4,10,4,4">
-            <TextBlock Text="ACCOUNT" Classes="muted" FontSize="11" FontWeight="SemiBold" />
-            <TextBlock Grid.Column="1" Text="CHARACTER"
-                       Classes="muted" FontSize="11" FontWeight="SemiBold" />
-            <TextBlock Grid.Column="2" Text="STATUS"
-                       Classes="muted" FontSize="11" FontWeight="SemiBold" />
-            <TextBlock Grid.Column="3" Text="DETAIL"
-                       Classes="muted" FontSize="11" FontWeight="SemiBold" />
-          </Grid>
-          <ScrollViewer Grid.Row="2" Margin="0,0,0,0">
-            <ItemsControl ItemsSource="{Binding Sessions}">
-              <ItemsControl.ItemTemplate>
-                <DataTemplate x:DataType="vm:LauncherSessionRowViewModel">
-                  <Border BorderBrush="#344559"
-                          BorderThickness="0,0,0,1"
-                          Padding="4,8">
-                    <Grid ColumnDefinitions="2*,2*,130,3*,Auto">
-                      <TextBlock Text="{Binding Account}"
-                                 FontWeight="SemiBold"
-                                 TextTrimming="CharacterEllipsis" />
-                      <TextBlock Grid.Column="1"
-                                 Text="{Binding Character}"
-                                 TextTrimming="CharacterEllipsis" />
-                      <TextBlock Grid.Column="2" Text="{Binding State}" />
-                      <StackPanel Grid.Column="3" Spacing="2">
-                        <TextBlock Text="{Binding Status}"
-                                   TextTrimming="CharacterEllipsis" Classes="muted" />
-                        <TextBlock Text="{Binding Error}"
-                                   Foreground="#FF9A9A"
-                                   IsVisible="{Binding HasError}"
-                                   TextTrimming="CharacterEllipsis" />
-                      </StackPanel>
-                      <Button Grid.Column="4" Content="Stop" Command="{Binding StopCommand}" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ItemsControl.ItemTemplate>
-            </ItemsControl>
-          </ScrollViewer>
-        </Grid>
-      </Border>
-    </Grid>
-
-    <Border Grid.Row="3" Background="#141C26" Padding="16,10">
-      <Grid ColumnDefinitions="*,Auto">
-        <StackPanel Spacing="2">
-          <TextBlock Text="{Binding OperationStatus}" />
-          <TextBlock Text="{Binding LastError}"
-                     Foreground="#FF9A9A"
-                     IsVisible="{Binding HasError}"
-                     TextWrapping="Wrap" />
+    <Grid Grid.Row="2" Margin="14,10" RowDefinitions="Auto,Auto,*">
+      <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+          <TextBlock Text="Accounts" Classes="section" />
+          <TextBlock Text="{Binding CheckedSelectionSummary}" Classes="muted" FontSize="12" VerticalAlignment="Center" />
         </StackPanel>
-        <Button Grid.Column="1"
-                Content="Cancel operation"
-                Command="{Binding CancelOperationCommand}" />
+        <Button Grid.Column="1" Content="Check servers" Command="{Binding CheckServersCommand}" />
+      </Grid>
+      <Grid Grid.Row="1" ColumnDefinitions="26,*,160,112,85,64,34" Margin="22,0,14,5" ColumnSpacing="6">
+        <TextBlock Grid.Column="1" Text="Server · status · players" Classes="muted" FontSize="12" />
+        <TextBlock Grid.Column="2" Text="Character" Classes="muted" FontSize="12" />
+        <TextBlock Grid.Column="3" Text="Launch mode" Classes="muted" FontSize="12" />
+        <TextBlock Grid.Column="4" Text="Session" Classes="muted" FontSize="12" />
+      </Grid>
+      <ScrollViewer Grid.Row="2" x:Name="AccountsScroll" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Focusable="True">
+        <StackPanel Spacing="5">
+          <TextBlock Text="Add your users and servers with the editors below." IsVisible="{Binding !HasAccounts}" Classes="muted" Margin="8,16" />
+          <ItemsControl ItemsSource="{Binding Accounts}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate x:DataType="vm:LauncherAccountGroupViewModel">
+                <Border Background="#141E24" BorderBrush="#35434B" BorderThickness="1" CornerRadius="3" Margin="0,0,0,5">
+                  <StackPanel>
+                    <ToggleButton IsChecked="{Binding IsExpanded, Mode=TwoWay}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#1D2931" Padding="10,4" MinHeight="30"><ToggleButton.Template><ControlTemplate><Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"><ContentPresenter Content="{TemplateBinding Content}" /></Border></ControlTemplate></ToggleButton.Template><StackPanel Orientation="Horizontal" Spacing="10"><TextBlock Text="▾" IsVisible="{Binding IsExpanded}" /><TextBlock Text="▸" IsVisible="{Binding !IsExpanded}" /><TextBlock Text="{Binding AccountName}" FontWeight="SemiBold" /></StackPanel></ToggleButton>
+                    <ItemsControl ItemsSource="{Binding Servers}" IsVisible="{Binding IsExpanded}">
+                      <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:LauncherAccountServerRowViewModel">
+                          <Border BorderBrush="#2B3941" BorderThickness="0,1,0,0" Padding="12,3,8,3">
+                            <Grid ColumnDefinitions="26,*,160,112,85,64,34" ColumnSpacing="6">
+                              <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" IsEnabled="{Binding CanEditSelection}" AutomationProperties.Name="Select account and server for batch launch" />
+                              <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                <TextBlock Text="{Binding ServerName}" TextTrimming="CharacterEllipsis" FontWeight="SemiBold" ToolTip.Tip="{Binding Endpoint}" />
+                                <TextBlock Text="{Binding ServerStatusText}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" ToolTip.Tip="Status checks the game endpoint. Player counts are reported by TreeStats, matched by server name." />
+                              </StackPanel>
+                              <ComboBox Grid.Column="2" ItemsSource="{Binding CharacterChoices}" SelectedItem="{Binding SelectedCharacter, Mode=TwoWay}" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsEnabled="{Binding CanEditSelection}" AutomationProperties.Name="Character" />
+                              <ComboBox Grid.Column="3" ItemsSource="{Binding LaunchModes}" SelectedItem="{Binding SelectedLaunchMode, Mode=TwoWay}" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsEnabled="{Binding CanEditSelection}" AutomationProperties.Name="Launch mode" />
+                              <TextBlock Grid.Column="4" Text="{Binding Status}" VerticalAlignment="Center" Classes="muted" FontSize="12" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Status}" />
+                              <Button Grid.Column="5" Content="Play" Classes="primary" Command="{Binding PlayCommand}" IsVisible="{Binding !IsActive}" VerticalAlignment="Center" HorizontalAlignment="Stretch" ToolTip.Tip="{Binding DisabledReason}" />
+                              <Button Grid.Column="5" Content="Stop" Command="{Binding StopCommand}" IsVisible="{Binding IsActive}" VerticalAlignment="Center" HorizontalAlignment="Stretch" />
+                              <Button Grid.Column="6" Content="···" Padding="4" Command="{Binding OptionsCommand}" VerticalAlignment="Center" AutomationProperties.Name="Character options" />
+                            </Grid>
+                          </Border>
+                        </DataTemplate>
+                      </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </ScrollViewer>
+    </Grid>
+    <Border Grid.Row="3" Background="#172128" Padding="14,8">
+      <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="6">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+          <WrapPanel Orientation="Horizontal">
+            <Button Content="Edit Users" Command="{Binding EditUsersTextCommand}" Margin="0,0,6,3" />
+            <Button Content="Edit Servers" Command="{Binding EditServersTextCommand}" Margin="0,0,6,3" />
+            <Button Content="Logon commands" Command="{Binding EditLogonCommandsTextCommand}" Margin="0,0,6,3" />
+          </WrapPanel>
+          <Button Grid.Column="1" x:Name="PlayCheckedButton" Content="Play selected" Classes="primary" Command="{Binding LaunchCheckedCommand}" VerticalAlignment="Top" />
+        </Grid>
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+          <TextBlock Text="{Binding OperationStatus}" Classes="muted" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding OperationStatus}" VerticalAlignment="Center" />
+          <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
+            <Button Content="Installation &amp; updates">
+              <Button.Flyout><Flyout><StackPanel Spacing="8" Width="280">
+                <TextBlock Text="Installation &amp; updates" Classes="section" />
+                <TextBlock Text="{Binding InstallationStatus}" TextWrapping="Wrap" Classes="muted" />
+                <Button Content="First-run setup" Command="{Binding FirstRunWizardShell.OpenCommand}" />
+                <Button Content="Verify files" Command="{Binding VerifyContentCommand}" />
+                <Button Content="Check for updates" Command="{Binding CheckForUpdatesCommand}" />
+                <TextBlock Text="{Binding UpdatePrompt.Status}" TextWrapping="Wrap" Classes="muted" />
+              </StackPanel></Flyout></Button.Flyout>
+            </Button>
+            <Button Content="Log" Command="{Binding OpenSessionLogCommand}" />
+            <Button Content="Cancel" IsVisible="{Binding IsBusy}" Command="{Binding CancelOperationCommand}" />
+          </StackPanel>
+        </Grid>
+        <TextBlock Grid.Row="2" Text="{Binding LastError}" Foreground="#FFB0A0" IsVisible="{Binding HasError}" TextWrapping="Wrap" MaxHeight="56" />
       </Grid>
     </Border>
 
@@ -465,6 +332,7 @@
         <StackPanel Spacing="14">
           <TextBlock Text="{Binding UpdatePrompt.Title}" FontSize="24" FontWeight="Bold" />
           <TextBlock Text="{Binding UpdatePrompt.Body}" TextWrapping="Wrap" />
+          <TextBlock Text="Close your active sessions before installing the update." TextWrapping="Wrap" Foreground="#DBB573" IsVisible="{Binding HasActiveSessions}" />
           <Border Background="#24344B"
                   Padding="10"
                   CornerRadius="5"
@@ -504,6 +372,55 @@
                     Command="{Binding UpdatePrompt.UpdateCommand}" />
           </StackPanel>
         </StackPanel>
+      </Border>
+    </Border>
+    <Border Grid.RowSpan="4" ZIndex="40" Background="#E010171C" IsVisible="{Binding TextEditor.IsOpen}"
+            KeyboardNavigation.TabNavigation="Cycle" KeyDown="OnModalKeyDown" AutomationProperties.Name="Text editor dialog">
+      <Border Classes="card" Margin="24" MaxWidth="880" VerticalAlignment="Stretch">
+        <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="10">
+          <TextBlock Text="{Binding TextEditor.Title}" FontSize="22" />
+          <TextBlock Grid.Row="1" Text="{Binding TextEditor.HelpText}" TextWrapping="Wrap" Classes="muted" />
+          <TextBox Grid.Row="2" x:Name="ProfileTextBox" Text="{Binding TextEditor.Text, Mode=TwoWay}" AcceptsReturn="True" AcceptsTab="True"
+                   FontFamily="Cascadia Mono,Consolas,monospace" TextWrapping="NoWrap" ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                   ScrollViewer.VerticalScrollBarVisibility="Auto" AutomationProperties.Name="Profile text" />
+          <TextBlock Grid.Row="3" Text="{Binding TextEditor.Error}" Foreground="#FFB0A0" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding TextEditor.CancelCommand}" />
+            <Button Content="Save" Classes="primary" Command="{Binding TextEditor.SaveCommand}" />
+          </StackPanel>
+        </Grid>
+      </Border>
+    </Border>
+    <Border Grid.RowSpan="4" ZIndex="40" Background="#E010171C" IsVisible="{Binding IsCharacterOptionsOpen}"
+            KeyboardNavigation.TabNavigation="Cycle" KeyDown="OnModalKeyDown" AutomationProperties.Name="Character options dialog">
+      <Border Classes="card" Margin="24" MaxWidth="720" VerticalAlignment="Stretch">
+        <Grid RowDefinitions="Auto,Auto,*,Auto,*,Auto,Auto" RowSpacing="8">
+          <TextBlock Text="{Binding SelectionTitle}" FontSize="22" />
+          <TextBlock Grid.Row="1" Text="Plugins · one id per line; blank loads all, none disables" Classes="muted" />
+          <TextBox Grid.Row="2" x:Name="CharacterPluginsTextBox" Text="{Binding CharacterPluginsText, Mode=TwoWay}" AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto" />
+          <TextBlock Grid.Row="3" Text="Logon commands · one command per line" Classes="muted" />
+          <TextBox Grid.Row="4" Text="{Binding CharacterLoginCommandsText, Mode=TwoWay}" AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto" />
+          <TextBlock Grid.Row="5" Text="{Binding LastError}" Foreground="#FFB0A0" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDesktopDialogCommand}" />
+            <Button Content="Save" Classes="primary" Command="{Binding SaveRowOptionsCommand}" />
+          </StackPanel>
+        </Grid>
+      </Border>
+    </Border>
+    <Border Grid.RowSpan="4" ZIndex="40" Background="#E010171C" IsVisible="{Binding IsSessionLogOpen}"
+            KeyboardNavigation.TabNavigation="Cycle" KeyDown="OnModalKeyDown" AutomationProperties.Name="Session log dialog">
+      <Border Classes="card" Margin="24" MaxWidth="960">
+        <Grid RowDefinitions="Auto,*,Auto" RowSpacing="12">
+          <TextBlock Text="Sessions" FontSize="22" />
+          <ScrollViewer Grid.Row="1"><ItemsControl ItemsSource="{Binding Sessions}"><ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vm:LauncherSessionRowViewModel"><Border Padding="6,8" BorderBrush="#35434B" BorderThickness="0,0,0,1">
+              <Grid ColumnDefinitions="160,160,*" ColumnSpacing="10"><TextBlock Text="{Binding Account}" TextWrapping="Wrap" /><TextBlock Grid.Column="1" Text="{Binding Character}" TextWrapping="Wrap" />
+                <StackPanel Grid.Column="2"><TextBlock Text="{Binding Status}" TextWrapping="Wrap" /><TextBlock Text="{Binding Error}" TextWrapping="Wrap" Foreground="#FFB0A0" /></StackPanel>
+              </Grid></Border></DataTemplate>
+          </ItemsControl.ItemTemplate></ItemsControl></ScrollViewer>
+          <Button Grid.Row="2" x:Name="SessionLogCloseButton" Content="Close" Command="{Binding CloseDesktopDialogCommand}" HorizontalAlignment="Right" />
+        </Grid>
       </Border>
     </Border>
   </Grid>

--- a/src/AcDream.Launcher/MainWindow.axaml.cs
+++ b/src/AcDream.Launcher/MainWindow.axaml.cs
@@ -45,6 +45,7 @@ public sealed partial class MainWindow : Window
         if (DataContext is LauncherWindowViewModel viewModel)
         {
             viewModel.PollStatus();
+            viewModel.PollServerHealth();
         }
     }
 
@@ -94,7 +95,7 @@ public sealed partial class MainWindow : Window
             {
                 if (focusToRestore?.Focus() != true)
                 {
-                    ProfilesTree.Focus();
+                    AccountsScroll.Focus();
                 }
             });
         }
@@ -104,7 +105,19 @@ public sealed partial class MainWindow : Window
 
     private void FocusActiveModal(LauncherWindowViewModel viewModel)
     {
-        if (viewModel.EditorDialog.IsOpen)
+        if (viewModel.TextEditor.IsOpen)
+        {
+            ProfileTextBox.Focus();
+        }
+        else if (viewModel.IsCharacterOptionsOpen)
+        {
+            CharacterPluginsTextBox.Focus();
+        }
+        else if (viewModel.IsSessionLogOpen)
+        {
+            SessionLogCloseButton.Focus();
+        }
+        else if (viewModel.EditorDialog.IsOpen)
         {
             Control target = viewModel.EditorDialog.Kind switch
             {

--- a/src/AcDream.Launcher/Program.cs
+++ b/src/AcDream.Launcher/Program.cs
@@ -74,7 +74,7 @@ internal static class Program
             File.WriteAllText(
                 path,
                 $"""
-                 acdream launcher crash report
+                 OpenAC launcher crash report
                  utc: {DateTime.UtcNow:O}
                  os: {Environment.OSVersion}
                  rid: {System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier}

--- a/src/AcDream.Launcher/ViewModels/FirstRunInstallerViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/FirstRunInstallerViewModel.cs
@@ -239,8 +239,8 @@ public sealed class FirstRunInstallerViewModel : ObservableObject, IDisposable
 
     public string CompletedBody => IsContentUpdate
         ? _completionRequirement
-            ?? "acdream built and verified the required world data. You can play now."
-        : "acdream built and verified your game content. You can play now.";
+            ?? "OpenAC built and verified the required world data. You can play now."
+        : "OpenAC built and verified your game content. You can play now.";
 
     public void SetCompletionRequirement(string? requirement)
     {
@@ -440,7 +440,7 @@ public sealed class FirstRunInstallerViewModel : ObservableObject, IDisposable
                 + $"{LauncherInstaller.FullRebuildRequiredFreeBytes / (1024d * 1024d * 1024d):N0} GiB "
                 + "while the optimized package is built beside the active one.";
         return $"This client needs recipe {migration.TargetRecipeVersion}: "
-            + $"{migration.Reason}. acdream will build {work} from your installed "
+            + $"{migration.Reason}. OpenAC will build {work} from your installed "
             + "Asheron's Call DAT files. The existing package stays in place "
             + $"until the new one has finished and verified. {estimate} "
             + "No work begins until you confirm below.";

--- a/src/AcDream.Launcher/ViewModels/FirstRunInstallerViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/FirstRunInstallerViewModel.cs
@@ -63,10 +63,9 @@ public sealed class FirstRunInstallerViewModel : ObservableObject, IDisposable
 
     public string Body => IsContentUpdate
         ? BuildContentUpdateBody()
-        : "Select the retail Asheron's Call DAT folder. acdream will validate "
-            + "the four required files, build DataDirectory/pak/acdream.pak, and "
-            + "verify its SHA-256 before enabling launch. No work begins until "
-            + "you choose Build and install.";
+        : "Choose your Asheron's Call data folder. OpenAC will check the required "
+            + "files and prepare the game content. First setup can take a while. "
+            + "Choose Build and install when you are ready.";
 
     public string StartActionText => IsContentUpdate
         ? _contentMigration?.Kind == ContentWorkKind.Overlay

--- a/src/AcDream.Launcher/ViewModels/LauncherAccountGroupViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherAccountGroupViewModel.cs
@@ -1,0 +1,101 @@
+using System.Collections.ObjectModel;
+using AcDream.Launcher.Core.Orchestration;
+using AcDream.Launcher.Core.Profiles;
+
+namespace AcDream.Launcher.ViewModels;
+
+public sealed class LauncherAccountGroupViewModel(string accountName) : ObservableObject
+{
+    private bool _isExpanded = true;
+    public string AccountName { get; } = accountName;
+    public bool IsExpanded { get => _isExpanded; set => SetProperty(ref _isExpanded, value); }
+    public ObservableCollection<LauncherAccountServerRowViewModel> Servers { get; } = [];
+}
+
+public sealed class LauncherAccountServerRowViewModel : ObservableObject
+{
+    public const string CharacterSelect = "Character select";
+    private readonly Func<LauncherAccountServerRowViewModel, string?> _disabledReason;
+    private readonly Action _changed;
+    private readonly Func<bool> _canInteract;
+    private bool _isChecked;
+    private string _selectedCharacter = CharacterSelect;
+    private string _selectedLaunchMode = "Graphical";
+    private string _endpoint = "";
+    private string _status = "Ready";
+    private string? _activeSessionId;
+    private bool? _isServerOnline;
+    private string _serverStatusText = "Not checked";
+
+    public LauncherAccountServerRowViewModel(string accountName, string serverName,
+        Func<LauncherAccountServerRowViewModel, string?> disabledReason, Action changed,
+        Func<LauncherAccountServerRowViewModel, Task> launch,
+        Func<string, Task> stop, Action<LauncherAccountServerRowViewModel> options,
+        Func<bool> canInteract)
+    {
+        AccountName = accountName;
+        ServerName = serverName;
+        _disabledReason = disabledReason;
+        _changed = changed;
+        _canInteract = canInteract;
+        PlayCommand = new AsyncRelayCommand(() => launch(this), () => CanPlay);
+        StopCommand = new AsyncRelayCommand(() => _activeSessionId is { } id ? stop(id) : Task.CompletedTask,
+            () => IsActive && canInteract());
+        OptionsCommand = new RelayCommand(() => options(this), canInteract);
+    }
+
+    public string AccountName { get; }
+    public string ServerName { get; }
+    public string Endpoint { get => _endpoint; private set => SetProperty(ref _endpoint, value); }
+    public bool IsChecked { get => _isChecked; set { if (SetProperty(ref _isChecked, value)) _changed(); } }
+    public ObservableCollection<string> CharacterChoices { get; } = [CharacterSelect];
+    public IReadOnlyList<string> LaunchModes { get; } = ["Graphical", "Headless"];
+    public string SelectedCharacter { get => _selectedCharacter; set { if (SetProperty(ref _selectedCharacter, value ?? CharacterSelect)) { NotifyState(); _changed(); } } }
+    public string SelectedLaunchMode { get => _selectedLaunchMode; set { if (SetProperty(ref _selectedLaunchMode, value ?? "Graphical")) { NotifyState(); _changed(); } } }
+    public LaunchMode Mode => SelectedLaunchMode == "Headless" ? LaunchMode.Headless : SelectedCharacter == CharacterSelect ? LaunchMode.GuiSelect : LaunchMode.Gui;
+    public string? CharacterName => SelectedCharacter == CharacterSelect ? null : SelectedCharacter;
+    public string Status { get => _status; private set => SetProperty(ref _status, value); }
+    public string ServerStatusText { get => _serverStatusText; set => SetProperty(ref _serverStatusText, value); }
+    public string HealthText { get => ServerStatusText; set { ServerStatusText = value; OnPropertyChanged(); } }
+    public bool? IsServerOnline { get => _isServerOnline; set => SetProperty(ref _isServerOnline, value); }
+    public bool IsActive => _activeSessionId is not null;
+    public bool CanEditSelection => !IsActive && _canInteract();
+    public bool CanPlay => DisabledReason.Length == 0;
+    public string DisabledReason => _disabledReason(this) ?? "";
+    public AsyncRelayCommand PlayCommand { get; }
+    public AsyncRelayCommand StopCommand { get; }
+    public RelayCommand OptionsCommand { get; }
+
+    internal void Update(LauncherServerSnapshot server, LauncherAccountSnapshot account, LauncherSessionSnapshot? session)
+    {
+        string endpoint = $"{server.Host}:{server.Port}";
+        if (Endpoint != endpoint)
+        {
+            IsServerOnline = null;
+            ServerStatusText = "Not checked";
+        }
+        Endpoint = endpoint;
+        string[] choices = [CharacterSelect, .. account.Characters.Select(character => character.Name)];
+        if (!CharacterChoices.SequenceEqual(choices))
+        {
+            string selected = SelectedCharacter;
+            CharacterChoices.Clear();
+            foreach (string choice in choices) CharacterChoices.Add(choice);
+            SelectedCharacter = choices.Contains(selected, StringComparer.Ordinal) ? selected : CharacterSelect;
+        }
+        _activeSessionId = session?.SessionId;
+        Status = session?.Status ?? account.ActivityStatus;
+        NotifyState();
+    }
+
+    internal void NotifyState()
+    {
+        OnPropertyChanged(nameof(IsActive));
+        OnPropertyChanged(nameof(CanEditSelection));
+        OnPropertyChanged(nameof(CanPlay));
+        OnPropertyChanged(nameof(DisabledReason));
+        PlayCommand.NotifyCanExecuteChanged();
+        StopCommand.NotifyCanExecuteChanged();
+        OptionsCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/src/AcDream.Launcher/ViewModels/LauncherAccountGroupViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherAccountGroupViewModel.cs
@@ -26,6 +26,7 @@ public sealed class LauncherAccountServerRowViewModel : ObservableObject
     private string? _activeSessionId;
     private bool? _isServerOnline;
     private string _serverStatusText = "Not checked";
+    private string? _launchError;
 
     public LauncherAccountServerRowViewModel(string accountName, string serverName,
         Func<LauncherAccountServerRowViewModel, string?> disabledReason, Action changed,
@@ -55,9 +56,12 @@ public sealed class LauncherAccountServerRowViewModel : ObservableObject
     public LaunchMode Mode => SelectedLaunchMode == "Headless" ? LaunchMode.Headless : SelectedCharacter == CharacterSelect ? LaunchMode.GuiSelect : LaunchMode.Gui;
     public string? CharacterName => SelectedCharacter == CharacterSelect ? null : SelectedCharacter;
     public string Status { get => _status; private set => SetProperty(ref _status, value); }
+    public string? LaunchError { get => _launchError; private set { if (SetProperty(ref _launchError, value)) OnPropertyChanged(nameof(HasLaunchError)); } }
+    public bool HasLaunchError => !string.IsNullOrEmpty(LaunchError);
     public string ServerStatusText { get => _serverStatusText; set => SetProperty(ref _serverStatusText, value); }
     public string HealthText { get => ServerStatusText; set { ServerStatusText = value; OnPropertyChanged(); } }
-    public bool? IsServerOnline { get => _isServerOnline; set => SetProperty(ref _isServerOnline, value); }
+    public bool? IsServerOnline { get => _isServerOnline; set { if (SetProperty(ref _isServerOnline, value)) OnPropertyChanged(nameof(ServerDotColor)); } }
+    public string ServerDotColor => IsServerOnline switch { true => "#65D99B", false => "#F17474", _ => "#89949C" };
     public bool IsActive => _activeSessionId is not null;
     public bool CanEditSelection => !IsActive && _canInteract();
     public bool CanPlay => DisabledReason.Length == 0;
@@ -83,8 +87,9 @@ public sealed class LauncherAccountServerRowViewModel : ObservableObject
             foreach (string choice in choices) CharacterChoices.Add(choice);
             SelectedCharacter = choices.Contains(selected, StringComparer.Ordinal) ? selected : CharacterSelect;
         }
-        _activeSessionId = session?.SessionId;
-        Status = session?.Status ?? account.ActivityStatus;
+        _activeSessionId = session?.IsActive == true ? session.SessionId : null;
+        Status = session?.Error ?? session?.Status ?? account.ActivityStatus;
+        LaunchError = session?.Error;
         NotifyState();
     }
 

--- a/src/AcDream.Launcher/ViewModels/LauncherUpdateViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherUpdateViewModel.cs
@@ -158,6 +158,13 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
 
     public RelayCommand CancelCommand { get; }
 
+    public bool AutoOpenDiscoveredUpdates { get; set; } = true;
+
+    public void OpenAvailableUpdate()
+    {
+        if (!_disposed && HasSomethingToUpdate && _canOpen()) IsOpen = true;
+    }
+
     public async Task StartupCheckAsync()
     {
         if (IsBusy || _disposed)
@@ -169,6 +176,8 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
         _cancellation = cancellation;
         IsStartupCheckComplete = false;
         StartupCheckSucceeded = false;
+        Error = null;
+        Status = "Checking for updates…";
         IsBusy = true;
         try
         {
@@ -176,6 +185,7 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
                 .ConfigureAwait(true);
             _check = await _updater.CheckAsync(cancellation.Token).ConfigureAwait(true);
             StartupCheckSucceeded = true;
+            Status = HasSomethingToUpdate ? "An update is available." : "OpenAC is up to date.";
             OnPropertyChanged(nameof(Body));
             OnPropertyChanged(nameof(IsClientUpdateAvailable));
             OnPropertyChanged(nameof(IsLauncherUpdateAvailable));
@@ -187,6 +197,9 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
         catch
         {
             _check = null;
+            Status = "Updates could not be checked. Try again from Installation & updates.";
+            OnPropertyChanged(nameof(IsClientUpdateAvailable));
+            OnPropertyChanged(nameof(IsLauncherUpdateAvailable));
         }
         finally
         {
@@ -215,7 +228,7 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
     /// question (notably required world-data work) has finished.</summary>
     public void TryOpenPendingUpdate()
     {
-        if (!_disposed && HasSomethingToUpdate && _canOpen())
+        if (AutoOpenDiscoveredUpdates && !_disposed && HasSomethingToUpdate && _canOpen())
         {
             IsOpen = true;
         }
@@ -292,6 +305,9 @@ public sealed class LauncherUpdateViewModel : ObservableObject, IDisposable
                 .ConfigureAwait(true);
             _onClientChanged();
             Status = "Update installed.";
+            _check = null;
+            OnPropertyChanged(nameof(IsClientUpdateAvailable));
+            OnPropertyChanged(nameof(IsLauncherUpdateAvailable));
             IsProgressIndeterminate = false;
             IsOpen = false;
         }

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Accounts.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Accounts.cs
@@ -1,0 +1,129 @@
+using System.Collections.ObjectModel;
+using AcDream.Launcher.Core.Orchestration;
+using AcDream.Launcher.Core.Profiles;
+
+namespace AcDream.Launcher.ViewModels;
+
+public sealed partial class LauncherWindowViewModel
+{
+    public ObservableCollection<LauncherAccountGroupViewModel> Accounts { get; } = [];
+    public bool HasAccounts => Accounts.Count != 0;
+    public AsyncRelayCommand LaunchCheckedCommand { get; private set; } = null!;
+    public string CheckedSelectionSummary => $"{AllAccountRows.Count(row => row.IsChecked)} selected · {AllAccountRows.Count(row => row.IsChecked && row.CanPlay)} ready";
+    private IEnumerable<LauncherAccountServerRowViewModel> AllAccountRows => Accounts.SelectMany(account => account.Servers);
+
+    private void InitializeAccountCommands() => LaunchCheckedCommand = new AsyncRelayCommand(
+        () => LaunchRowsAsync(AllAccountRows.Where(row => row.IsChecked).ToArray()),
+        () => CanInteract && AllAccountRows.Any(row => row.IsChecked && row.CanPlay));
+
+    public void RefreshProfiles() => RefreshFromCore();
+
+    private void RefreshAccountRows(LauncherStateSnapshot snapshot)
+    {
+        var retained = new HashSet<LauncherAccountServerRowViewModel>();
+        foreach (LauncherServerSnapshot server in snapshot.Servers)
+        foreach (LauncherAccountSnapshot account in server.Accounts)
+        {
+            LauncherAccountGroupViewModel? group = Accounts.FirstOrDefault(item => item.AccountName == account.AccountName);
+            if (group is null)
+            {
+                group = new LauncherAccountGroupViewModel(account.AccountName);
+                Accounts.Add(group);
+            }
+            LauncherAccountServerRowViewModel? row = group.Servers.FirstOrDefault(item => item.ServerName == server.Name);
+            if (row is null)
+            {
+                row = new LauncherAccountServerRowViewModel(account.AccountName, server.Name,
+                    GetRowDisabledReason, NotifyAccountCommands, item => LaunchRowsAsync([item]),
+                    StopSessionAsync, OpenRowOptions, () => CanInteract);
+                group.Servers.Add(row);
+            }
+            retained.Add(row);
+            row.Update(server, account, snapshot.Sessions.FirstOrDefault(session => session.IsActive
+                && session.ServerName == server.Name && session.AccountName == account.AccountName));
+        }
+        foreach (LauncherAccountGroupViewModel group in Accounts.ToArray())
+        {
+            foreach (LauncherAccountServerRowViewModel row in group.Servers.Where(row => !retained.Contains(row)).ToArray())
+                group.Servers.Remove(row);
+            if (group.Servers.Count == 0) Accounts.Remove(group);
+        }
+    }
+
+    private string? GetRowDisabledReason(LauncherAccountServerRowViewModel row) =>
+        !CanInteract ? "Finish the current operation or close the dialog first."
+        : GetRowLaunchBlock(row);
+
+    private string? GetRowLaunchBlock(LauncherAccountServerRowViewModel row) => GetRowLaunchBlock(row, row.CharacterName, row.Mode);
+
+    private string? GetRowLaunchBlock(LauncherAccountServerRowViewModel row, string? characterName, LaunchMode mode)
+    {
+        if (_isInstallationChecking || _isClientCompatibilityCheckBlocking) return "Checking installation and client compatibility…";
+        if (row.IsActive) return "This account already has an active session on this server.";
+        if (mode == LaunchMode.Headless && characterName is null) return "Choose a character for Headless mode.";
+        if (row.SelectedLaunchMode is not ("Graphical" or "Headless")) return "Choose Graphical or Headless.";
+        LauncherStateSnapshot current = _orchestrator.GetSnapshot();
+        LauncherAccountSnapshot? account = current.Servers.FirstOrDefault(server => server.Name == row.ServerName)
+            ?.Accounts.FirstOrDefault(account => account.AccountName == row.AccountName);
+        if (account is null) return "This account is no longer configured on this server.";
+        if (account.HasRunningActivity || current.Sessions.Any(session => session.IsActive
+            && session.ServerName == row.ServerName && session.AccountName == row.AccountName)) return "This account already has an active session on this server.";
+        if (characterName is { } name && !account.Characters.Any(character => character.Name == name)) return "Choose a current character.";
+        LauncherCapability capability = _orchestrator.GetAccountLaunchCapability(row.ServerName, row.AccountName, mode);
+        return capability.IsAvailable ? null : capability.Reason ?? "Launch unavailable.";
+    }
+
+    private async Task LaunchRowsAsync(LauncherAccountServerRowViewModel[] rows)
+    {
+        if (!CanInteract) return;
+        var pending = rows.Select(row => (Row: row, Character: row.CharacterName, Mode: row.Mode)).ToArray();
+        if (pending.Length == 0) return;
+        using var cancellation = new CancellationTokenSource();
+        CancellationToken token = cancellation.Token;
+        _operationCancellation = cancellation;
+        IsBusy = true;
+        LastError = null;
+        int started = 0;
+        var errors = new List<string>();
+        try
+        {
+            foreach (var item in pending)
+            {
+                token.ThrowIfCancellationRequested();
+                string? block = GetRowLaunchBlock(item.Row, item.Character, item.Mode);
+                if (block is not null) { errors.Add($"{item.Row.AccountName} / {item.Row.ServerName}: {block}"); continue; }
+                OperationStatus = $"Launching {started + 1} of {pending.Length}…";
+                try
+                {
+                    await _orchestrator.LaunchAsync(item.Row.ServerName, item.Row.AccountName,
+                        item.Character, item.Mode, token).ConfigureAwait(true);
+                    started++;
+                }
+                catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { throw; }
+                catch (Exception ex) { errors.Add($"{item.Row.AccountName} / {item.Row.ServerName}: {SafeDisplayError(ex, secret: null)}"); }
+            }
+            OperationStatus = $"Started {started} of {pending.Length} selected sessions.";
+        }
+        catch (OperationCanceledException) { OperationStatus = $"Launch cancelled. Started {started} sessions."; }
+        finally
+        {
+            LastError = errors.Count == 0 ? null : string.Join(Environment.NewLine, errors);
+            _operationCancellation = null;
+            if (!_disposed)
+            {
+                IsBusy = false;
+                RefreshFromCore();
+            }
+        }
+    }
+
+    private void OpenRowOptions(LauncherAccountServerRowViewModel row) => OpenAccountRowOptions(row);
+
+    private void NotifyAccountCommands()
+    {
+        LaunchCheckedCommand?.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(CheckedSelectionSummary));
+        OnPropertyChanged(nameof(HasAccounts));
+        foreach (LauncherAccountServerRowViewModel row in AllAccountRows) row.NotifyState();
+    }
+}

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Accounts.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Accounts.cs
@@ -21,6 +21,8 @@ public sealed partial class LauncherWindowViewModel
     private void RefreshAccountRows(LauncherStateSnapshot snapshot)
     {
         var retained = new HashSet<LauncherAccountServerRowViewModel>();
+        foreach (string name in snapshot.SharedAccountNames ?? [])
+            if (!Accounts.Any(account => account.AccountName == name)) Accounts.Add(new LauncherAccountGroupViewModel(name));
         foreach (LauncherServerSnapshot server in snapshot.Servers)
         foreach (LauncherAccountSnapshot account in server.Accounts)
         {
@@ -39,14 +41,14 @@ public sealed partial class LauncherWindowViewModel
                 group.Servers.Add(row);
             }
             retained.Add(row);
-            row.Update(server, account, snapshot.Sessions.FirstOrDefault(session => session.IsActive
-                && session.ServerName == server.Name && session.AccountName == account.AccountName));
+            row.Update(server, account, snapshot.Sessions.OrderByDescending(session => session.CreatedAt).FirstOrDefault(session =>
+                session.ServerName == server.Name && session.AccountName == account.AccountName));
         }
         foreach (LauncherAccountGroupViewModel group in Accounts.ToArray())
         {
             foreach (LauncherAccountServerRowViewModel row in group.Servers.Where(row => !retained.Contains(row)).ToArray())
                 group.Servers.Remove(row);
-            if (group.Servers.Count == 0) Accounts.Remove(group);
+            if (group.Servers.Count == 0 && !(snapshot.SharedAccountNames?.Contains(group.AccountName) ?? false)) Accounts.Remove(group);
         }
     }
 
@@ -95,9 +97,10 @@ public sealed partial class LauncherWindowViewModel
                 OperationStatus = $"Launching {started + 1} of {pending.Length}…";
                 try
                 {
-                    await _orchestrator.LaunchAsync(item.Row.ServerName, item.Row.AccountName,
+                    var result = await _orchestrator.LaunchAsync(item.Row.ServerName, item.Row.AccountName,
                         item.Character, item.Mode, token).ConfigureAwait(true);
-                    started++;
+                    if (result.State is not (LauncherActivityState.Failed or LauncherActivityState.Cancelled) && result.ExitCode is not (> 0 or < 0)) started++;
+                    else errors.Add($"{item.Row.AccountName} / {item.Row.ServerName}: {result.Error ?? result.Status}");
                 }
                 catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { throw; }
                 catch (Exception ex) { errors.Add($"{item.Row.AccountName} / {item.Row.ServerName}: {SafeDisplayError(ex, secret: null)}"); }

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Desktop.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Desktop.cs
@@ -1,0 +1,167 @@
+using System.ComponentModel;
+using AcDream.Launcher.Core.Profiles;
+using AcDream.Launcher.Core.Status;
+
+namespace AcDream.Launcher.ViewModels;
+
+public sealed partial class LauncherWindowViewModel
+{
+    private IServerHealthService? _serverHealth;
+    private DateTimeOffset _nextHealthCheck;
+    private readonly CancellationTokenSource _healthCancellation = new();
+    private bool _isCharacterOptionsOpen;
+    private bool _isSessionLogOpen;
+
+    public ProfileTextEditorViewModel TextEditor { get; private set; } = null!;
+    public RelayCommand EditUsersTextCommand { get; private set; } = null!;
+    public RelayCommand EditServersTextCommand { get; private set; } = null!;
+    public RelayCommand EditLogonCommandsTextCommand { get; private set; } = null!;
+    public RelayCommand ReviewUpdateCommand { get; private set; } = null!;
+    public AsyncRelayCommand CheckForUpdatesCommand { get; private set; } = null!;
+    public AsyncRelayCommand CheckServersCommand { get; private set; } = null!;
+    public RelayCommand OpenSessionLogCommand { get; private set; } = null!;
+    public RelayCommand CloseDesktopDialogCommand { get; private set; } = null!;
+    public RelayCommand SaveRowOptionsCommand { get; private set; } = null!;
+    public bool ShowUpdateBanner => UpdatePrompt.IsClientUpdateAvailable || UpdatePrompt.IsLauncherUpdateAvailable;
+    public bool HasActiveSessions => Sessions.Any(session => session.IsActive);
+    public bool IsCharacterOptionsOpen
+    {
+        get => _isCharacterOptionsOpen;
+        private set { if (SetProperty(ref _isCharacterOptionsOpen, value)) NotifyDesktopModal(); }
+    }
+    public bool IsSessionLogOpen
+    {
+        get => _isSessionLogOpen;
+        private set { if (SetProperty(ref _isSessionLogOpen, value)) NotifyDesktopModal(); }
+    }
+
+    private void InitializeDesktop()
+    {
+        TextEditor = new ProfileTextEditorViewModel(_orchestrator);
+        TextEditor.PropertyChanged += OnModalPropertyChanged;
+        UpdatePrompt.PropertyChanged += OnDesktopUpdateChanged;
+        EditUsersTextCommand = new RelayCommand(() => OpenTextEditor(LauncherTextEditorKind.Users), () => CanInteract);
+        EditServersTextCommand = new RelayCommand(() => OpenTextEditor(LauncherTextEditorKind.Servers), () => CanInteract);
+        EditLogonCommandsTextCommand = new RelayCommand(() => OpenTextEditor(LauncherTextEditorKind.LogonCommands), () => CanInteract);
+        ReviewUpdateCommand = new RelayCommand(UpdatePrompt.OpenAvailableUpdate, () => CanInteract && ShowUpdateBanner);
+        CheckForUpdatesCommand = new AsyncRelayCommand(async () =>
+        {
+            await UpdatePrompt.StartupCheckAsync();
+            if (ShowUpdateBanner) UpdatePrompt.OpenAvailableUpdate();
+        }, () => CanInteract && !UpdatePrompt.IsBusy);
+        CheckServersCommand = new AsyncRelayCommand(CheckServerHealthAsync, () => _serverHealth is not null && !_disposed);
+        OpenSessionLogCommand = new RelayCommand(() => IsSessionLogOpen = true, () => CanInteract);
+        CloseDesktopDialogCommand = new RelayCommand(CloseDesktopDialogs);
+        SaveRowOptionsCommand = new RelayCommand(() =>
+        {
+            SaveCharacterSettings();
+            if (!HasError) IsCharacterOptionsOpen = false;
+        }, () => IsCharacterOptionsOpen && !IsBusy);
+    }
+
+    private void OpenTextEditor(LauncherTextEditorKind kind)
+    {
+        try { TextEditor.Open(kind); }
+        catch (Exception ex) { LastError = SafeDisplayError(ex, secret: null); }
+    }
+
+    public void ConfigureServerHealth(IServerHealthService service) => _serverHealth = service;
+
+    public void PollServerHealth()
+    {
+        if (_disposed || _serverHealth is null || DateTimeOffset.UtcNow < _nextHealthCheck) return;
+        _nextHealthCheck = DateTimeOffset.UtcNow.AddSeconds(30);
+        CheckServersCommand.Execute(null);
+    }
+
+    private async Task CheckServerHealthAsync()
+    {
+        if (_serverHealth is null) return;
+        CancellationToken token = _healthCancellation.Token;
+        var servers = _orchestrator.GetSnapshot().Servers.ToArray();
+        using var limit = new SemaphoreSlim(4);
+        try
+        {
+            await Task.WhenAll(servers.Select(async server =>
+            {
+                await limit.WaitAsync(token);
+                try
+                {
+                    ServerHealthSnapshot result = await _serverHealth.CheckAsync(server.Host, server.Port, server.Name, token);
+                    _dispatcher.Post(() =>
+                    {
+                        if (_disposed) return;
+                        string count = result.PlayerCount is { } value ? $"{value:N0} players" : "— players";
+                        if (result.IsPlayerCountStale) count += " (stale)";
+                        string status = result.IsReachable == true ? "● Online" : "○ No response";
+                        string latency = result.LatencyMilliseconds is { } ms ? $" · {ms:0} ms" : "";
+                        foreach (var row in AllAccountRows.Where(row => row.ServerName == server.Name && row.Endpoint == $"{server.Host}:{server.Port}"))
+                        {
+                            row.IsServerOnline = result.IsReachable;
+                            row.ServerStatusText = $"{status} · {count}{latency}";
+                        }
+                    });
+                }
+                finally { limit.Release(); }
+            }));
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested) { }
+        catch (Exception)
+        {
+            if (!_disposed) OperationStatus = "Server status could not be checked. You can still launch.";
+        }
+        _nextHealthCheck = DateTimeOffset.UtcNow.AddSeconds(30);
+    }
+
+    private void OpenAccountRowOptions(LauncherAccountServerRowViewModel row)
+    {
+        if (row.CharacterName is null) { OpenTextEditor(LauncherTextEditorKind.Users); return; }
+        SelectedNode = Servers.FirstOrDefault(server => server.ServerName == row.ServerName)?.Children
+            .FirstOrDefault(account => account.AccountName == row.AccountName)?.Children
+            .FirstOrDefault(character => character.CharacterName == row.CharacterName);
+        if (SelectedNode is not null)
+        {
+            CharacterLaunchMode = row.Mode;
+            IsCharacterOptionsOpen = true;
+        }
+    }
+
+    private void NotifyDesktopModal()
+    {
+        OnPropertyChanged(nameof(IsModalOpen));
+        NotifyCommandStates();
+    }
+
+    public void CloseDesktopDialogs()
+    {
+        IsCharacterOptionsOpen = false;
+        IsSessionLogOpen = false;
+    }
+
+    private void OnDesktopUpdateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(ShowUpdateBanner));
+        NotifyDesktopCommands();
+    }
+
+    private void NotifyDesktopCommands()
+    {
+        OnPropertyChanged(nameof(HasActiveSessions));
+        EditUsersTextCommand?.NotifyCanExecuteChanged();
+        EditServersTextCommand?.NotifyCanExecuteChanged();
+        EditLogonCommandsTextCommand?.NotifyCanExecuteChanged();
+        ReviewUpdateCommand?.NotifyCanExecuteChanged();
+        CheckForUpdatesCommand?.NotifyCanExecuteChanged();
+        OpenSessionLogCommand?.NotifyCanExecuteChanged();
+        SaveRowOptionsCommand?.NotifyCanExecuteChanged();
+    }
+
+    private void DisposeDesktop()
+    {
+        _healthCancellation.Cancel();
+        _healthCancellation.Dispose();
+        TextEditor.PropertyChanged -= OnModalPropertyChanged;
+        TextEditor.Close();
+        UpdatePrompt.PropertyChanged -= OnDesktopUpdateChanged;
+    }
+}

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Desktop.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.Desktop.cs
@@ -93,7 +93,7 @@ public sealed partial class LauncherWindowViewModel
                         if (_disposed) return;
                         string count = result.PlayerCount is { } value ? $"{value:N0} players" : "— players";
                         if (result.IsPlayerCountStale) count += " (stale)";
-                        string status = result.IsReachable == true ? "● Online" : "○ No response";
+                        string status = result.IsReachable == true ? "Online" : "Offline · no response";
                         string latency = result.LatencyMilliseconds is { } ms ? $" · {ms:0} ms" : "";
                         foreach (var row in AllAccountRows.Where(row => row.ServerName == server.Name && row.Endpoint == $"{server.Host}:{server.Port}"))
                         {

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
@@ -8,7 +8,7 @@ using AcDream.Launcher.Core.Updates;
 
 namespace AcDream.Launcher.ViewModels;
 
-public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
+public sealed partial class LauncherWindowViewModel : ObservableObject, IDisposable
 {
     private readonly ILauncherOrchestrator _orchestrator;
     private static readonly TimeSpan GracefulStopTimeout = TimeSpan.FromSeconds(30);
@@ -68,6 +68,7 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
         UpdatePrompt.PropertyChanged += OnModalPropertyChanged;
         UpdatePrompt.StartupCheckCompleted += OnStartupUpdateCheckCompleted;
 
+        InitializeAccountCommands();
         AddServerCommand = new RelayCommand(OpenAddServerDialog, () => CanInteract);
         AddAccountCommand = new RelayCommand(OpenAddAccountDialog, CanAddAccount);
         AddCharacterCommand = new RelayCommand(OpenAddCharacterDialog, CanAddCharacter);
@@ -94,6 +95,7 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
         VerifyContentCommand = new AsyncRelayCommand(
             VerifyContentAsync,
             () => CanInteract && Sessions.All(session => !session.IsActive));
+        InitializeDesktop();
     }
 
     public ObservableCollection<LauncherTreeNodeViewModel> Servers { get; } = [];
@@ -149,7 +151,10 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
     public bool IsModalOpen =>
         EditorDialog.IsOpen
         || FirstRunWizardShell.IsOpen
-        || UpdatePrompt.IsOpen;
+        || UpdatePrompt.IsOpen
+        || (TextEditor?.IsOpen ?? false)
+        || IsCharacterOptionsOpen
+        || IsSessionLogOpen;
 
     private bool CanInteract => !IsBusy && !IsModalOpen;
 
@@ -352,6 +357,7 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
             return;
         }
 
+        DisposeDesktop();
         _disposed = true;
         _startupCancellation.Cancel();
         _operationCancellation?.Cancel();
@@ -502,7 +508,12 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
 
     public void CloseActiveModal()
     {
-        if (EditorDialog.IsOpen)
+        CloseDesktopDialogs();
+        if (TextEditor.IsOpen)
+        {
+            TextEditor.Close();
+        }
+        else if (EditorDialog.IsOpen)
         {
             EditorDialog.Close();
         }
@@ -521,6 +532,7 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
         SelectionKey? previousSelection = preferredSelection ?? SelectionKey.From(SelectedNode);
         LauncherStateSnapshot snapshot = _orchestrator.GetSnapshot();
         _snapshot = snapshot;
+        RefreshAccountRows(snapshot);
 
         Servers.Clear();
         foreach (LauncherServerSnapshot server in snapshot.Servers)
@@ -1227,6 +1239,8 @@ public sealed class LauncherWindowViewModel : ObservableObject, IDisposable
 
     private void NotifyCommandStates()
     {
+        NotifyAccountCommands();
+        NotifyDesktopCommands();
         AddServerCommand.NotifyCanExecuteChanged();
         AddAccountCommand.NotifyCanExecuteChanged();
         AddCharacterCommand.NotifyCanExecuteChanged();

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
@@ -1163,7 +1163,7 @@ public sealed partial class LauncherWindowViewModel : ObservableObject, IDisposa
         {
             _pendingInstalledContent = record;
             _isClientCompatibilityPending = true;
-            const string requirement = "acdream built and verified the world data. "
+            const string requirement = "OpenAC built and verified the world data. "
                 + "Install the matching game update next; Play stays disabled until it finishes.";
             FirstRunWizardShell.SetCompletionRequirement(requirement);
             _orchestrator.SetInstallationState(

--- a/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/LauncherWindowViewModel.cs
@@ -343,6 +343,8 @@ public sealed partial class LauncherWindowViewModel : ObservableObject, IDisposa
         try
         {
             _orchestrator.PollStatus();
+            // Availability also changes when a reconnect delay expires, without a session event.
+            NotifyAccountCommands();
         }
         catch (Exception ex)
         {

--- a/src/AcDream.Launcher/ViewModels/ProfileTextEditorViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/ProfileTextEditorViewModel.cs
@@ -35,8 +35,8 @@ public sealed class ProfileTextEditorViewModel : ObservableObject
         Title = kind switch { LauncherTextEditorKind.Users => "Edit Users", LauncherTextEditorKind.Servers => "Edit Servers", _ => "Logon commands" };
         HelpText = kind switch
         {
-            LauncherTextEditorKind.Users => "One user per line: username | password | server1, server2. Omit servers to use all configured servers. Empty passwords are allowed. Put values containing | or commas in double quotes (JSON escapes). Removing an association removes its saved characters.",
-            LauncherTextEditorKind.Servers => "One server per line: name | host | port. Example: Local | 127.0.0.1 | 9000. Put names containing | or commas in double quotes. Keep the name to retain its accounts; renaming or removing it removes its account associations.",
+            LauncherTextEditorKind.Users => "One user per line: username | password. Every user lists all configured servers, including servers added later. Empty passwords are allowed. Quote values containing | with double quotes (JSON escapes).",
+            LauncherTextEditorKind.Servers => "One server per line: name | host | port. Example: Local | 127.0.0.1 | 9000. Put names containing | or commas in double quotes. Every server appears under every user. Keep the name to retain its saved characters.",
             _ => "Commands run for the named character after login. Keep server, account and character unchanged; edit commands in order. Use [] for no commands. Removing an entry clears its commands.",
         };
         Error = null;

--- a/src/AcDream.Launcher/ViewModels/ProfileTextEditorViewModel.cs
+++ b/src/AcDream.Launcher/ViewModels/ProfileTextEditorViewModel.cs
@@ -1,0 +1,62 @@
+using AcDream.Launcher.Core.Orchestration;
+using AcDream.Launcher.Core.Profiles;
+
+namespace AcDream.Launcher.ViewModels;
+
+public sealed class ProfileTextEditorViewModel : ObservableObject
+{
+    private readonly ILauncherOrchestrator _orchestrator;
+    private bool _isOpen;
+    private string _title = "";
+    private string _helpText = "";
+    private string _text = "";
+    private string? _error;
+    private string _originalText = "";
+    private LauncherTextEditorKind _kind;
+
+    public ProfileTextEditorViewModel(ILauncherOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+        SaveCommand = new RelayCommand(Save, () => IsOpen);
+        CancelCommand = new RelayCommand(Close, () => IsOpen);
+    }
+
+    public bool IsOpen { get => _isOpen; private set { if (SetProperty(ref _isOpen, value)) { SaveCommand.NotifyCanExecuteChanged(); CancelCommand.NotifyCanExecuteChanged(); } } }
+    public string Title { get => _title; private set => SetProperty(ref _title, value); }
+    public string HelpText { get => _helpText; private set => SetProperty(ref _helpText, value); }
+    public string Text { get => _text; set => SetProperty(ref _text, value); }
+    public string? Error { get => _error; private set => SetProperty(ref _error, value); }
+    public RelayCommand SaveCommand { get; }
+    public RelayCommand CancelCommand { get; }
+
+    public void Open(LauncherTextEditorKind kind)
+    {
+        _kind = kind;
+        Title = kind switch { LauncherTextEditorKind.Users => "Edit Users", LauncherTextEditorKind.Servers => "Edit Servers", _ => "Logon commands" };
+        HelpText = kind switch
+        {
+            LauncherTextEditorKind.Users => "One user per line: username | password | server1, server2. Omit servers to use all configured servers. Empty passwords are allowed. Put values containing | or commas in double quotes (JSON escapes). Removing an association removes its saved characters.",
+            LauncherTextEditorKind.Servers => "One server per line: name | host | port. Example: Local | 127.0.0.1 | 9000. Put names containing | or commas in double quotes. Keep the name to retain its accounts; renaming or removing it removes its account associations.",
+            _ => "Commands run for the named character after login. Keep server, account and character unchanged; edit commands in order. Use [] for no commands. Removing an entry clears its commands.",
+        };
+        Error = null;
+        Text = _originalText = _orchestrator.ReadProfileText(kind);
+        IsOpen = true;
+    }
+
+    public void Close()
+    {
+        IsOpen = false;
+        Text = _originalText = "";
+        Error = null;
+    }
+
+    private void Save()
+    {
+        try { _orchestrator.SaveProfileText(_kind, Text, _originalText); Close(); }
+        catch (Exception ex) when (ex is LauncherProfileException or IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            Error = ex is LauncherProfileException ? ex.Message : "Unable to save. Stop active sessions and check that the profile folder is writable.";
+        }
+    }
+}

--- a/tests/AcDream.Launcher.Core.Tests/Orchestration/LauncherOrchestratorTests.cs
+++ b/tests/AcDream.Launcher.Core.Tests/Orchestration/LauncherOrchestratorTests.cs
@@ -36,6 +36,22 @@ public sealed class LauncherOrchestratorTests : IDisposable
     }
 
     [Fact]
+    public async Task AssetVersionCrashProducesActionableErrorWithoutExposingStderr()
+    {
+        var supervisors = new FakeSupervisorFactory();
+        using var orchestrator = CreateOrchestrator(supervisorFactory: supervisors);
+        await orchestrator.LaunchAsync("Local ACE", "testaccount", "+Acdream", LaunchMode.Gui);
+        var supervisor = Assert.Single(supervisors.Created);
+        string path = supervisor.Spec!.StderrLogPath!;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "prepared asset package does not match: bake tool 10 != 6 " + Password);
+        supervisor.Exit(1);
+        string error = Assert.Single(orchestrator.GetSnapshot().Sessions).Error!;
+        Assert.Contains("Update the client", error);
+        Assert.DoesNotContain(Password, error);
+    }
+
+    [Fact]
     public async Task RunningHostHoldsSharedUpdateLeaseUntilProcessTerminalState()
     {
         var supervisors = new FakeSupervisorFactory();

--- a/tests/AcDream.Launcher.Core.Tests/Profiles/LauncherProfileTextTests.cs
+++ b/tests/AcDream.Launcher.Core.Tests/Profiles/LauncherProfileTextTests.cs
@@ -1,0 +1,114 @@
+using AcDream.Launcher.Core.Profiles;
+
+namespace AcDream.Launcher.Core.Tests.Profiles;
+
+public sealed class LauncherProfileTextTests
+{
+    private static LauncherProfileDocument Sample() => new()
+    {
+        Servers = [new() { Name = "One", Host = "localhost", Port = 9000,
+            Accounts = [new() { Account = "User", Password = "first", Characters = [new() { Name = "Hero", Id = "0x50000001", LaunchMode = LaunchMode.Headless, Plugins = ["plugin"], LoginCommands = ["/help"] }] }] },
+            new() { Name = "Two", Host = "localhost", Port = 9001, Accounts = [new() { Account = "User", Password = "second" }] }],
+    };
+
+    [Fact]
+    public void UserRoundTripPreservesDistinctCredentialsAndCharacterSettings()
+    {
+        var document = Sample();
+        string text = LauncherProfileText.Read(document, LauncherTextEditorKind.Users);
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, text);
+        Assert.Equal("first", document.Servers[0].Accounts[0].Password);
+        Assert.Equal("second", document.Servers[1].Accounts[0].Password);
+        var character = document.Servers[0].Accounts[0].Characters[0];
+        Assert.Equal(LaunchMode.Headless, character.LaunchMode);
+        Assert.Equal(["plugin"], character.Plugins);
+        Assert.Equal(["/help"], character.LoginCommands);
+    }
+
+    [Theory]
+    [InlineData("New | secret | One, Unknown")]
+    [InlineData("New | secret | One, One")]
+    [InlineData("New | \"secret | One")]
+    [InlineData("New")]
+    public void InvalidUsersDoNotPartiallyReplaceProfiles(string text)
+    {
+        var document = Sample();
+        string before = LauncherProfileText.Read(document, LauncherTextEditorKind.Users);
+        var error = Assert.Throws<LauncherProfileException>(() => LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, text));
+        Assert.DoesNotContain("secret", error.Message);
+        Assert.Equal(before, LauncherProfileText.Read(document, LauncherTextEditorKind.Users));
+    }
+
+    [Fact]
+    public void ServerEndpointEditRetainsAccounts()
+    {
+        var document = Sample();
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Servers, "One | new.example | 9010");
+        Assert.Single(document.Servers);
+        Assert.Equal("new.example", document.Servers[0].Host);
+        Assert.Equal("Hero", document.Servers[0].Accounts[0].Characters[0].Name);
+    }
+
+    [Fact]
+    public void FailedDiskWriteRollsBackTheWholeUserEdit()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "launcher-text-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var store = new LauncherProfileStore(directory);
+            store.AddServer("One", "localhost", 9000);
+            store.AddAccount("One", "Original", "original-password");
+            var error = Record.Exception(() => store.ExecuteTransaction(() => LauncherProfileText.Apply(store.Document,
+                LauncherTextEditorKind.Users, "New | new-password | One")));
+            Assert.True(error is IOException or UnauthorizedAccessException);
+            Assert.Equal("Original", store.Document.Servers[0].Accounts[0].Account);
+            Assert.Equal("original-password", store.Document.Servers[0].Accounts[0].Password);
+        }
+        finally { Directory.Delete(directory); }
+    }
+
+    [Fact]
+    public void BareUsernameAndEmptyPasswordUsesAllServers()
+    {
+        var document = Sample();
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, "\r\nNew | \r\n");
+        Assert.All(document.Servers, server =>
+        {
+            Assert.Equal("New", Assert.Single(server.Accounts).Account);
+            Assert.Equal("", server.Accounts[0].Password);
+        });
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, " \r\n ");
+        Assert.All(document.Servers, server => Assert.Empty(server.Accounts));
+    }
+
+    [Fact]
+    public void QuotedSeparatorsWhitespaceAndEscapesRoundTrip()
+    {
+        var document = Sample();
+        document.Servers[0].Name = "Server, One | Test";
+        document.Servers[0].Accounts[0].Password = " secret|,\\\"\r\n ";
+        document.Servers[0].Accounts[0].Account = " User | One ";
+        string users = LauncherProfileText.Read(document, LauncherTextEditorKind.Users);
+        string servers = LauncherProfileText.Read(document, LauncherTextEditorKind.Servers);
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Servers, servers);
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, users);
+        Assert.Equal("Server, One | Test", document.Servers[0].Name);
+        Assert.Equal(" User | One ", document.Servers[0].Accounts[0].Account);
+        Assert.Equal(" secret|,\\\"\r\n ", document.Servers[0].Accounts[0].Password);
+    }
+
+    [Fact]
+    public void CommandsChangeOnlyCommandsAndValidateAllBeforeApplying()
+    {
+        var document = Sample();
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.LogonCommands,
+            "[{\"server\":\"One\",\"account\":\"User\",\"character\":\"Hero\",\"commands\":[\"/one\",\"/two\"]}]");
+        var character = document.Servers[0].Accounts[0].Characters[0];
+        Assert.Equal(["/one", "/two"], character.LoginCommands);
+        Assert.Equal(LaunchMode.Headless, character.LaunchMode);
+        Assert.Throws<LauncherProfileException>(() => LauncherProfileText.Apply(document, LauncherTextEditorKind.LogonCommands,
+            "[{\"server\":\"One\",\"account\":\"User\",\"character\":\"Unknown\",\"commands\":[]}]"));
+        Assert.Equal(["/one", "/two"], character.LoginCommands);
+    }
+}

--- a/tests/AcDream.Launcher.Core.Tests/Profiles/LauncherProfileTextTests.cs
+++ b/tests/AcDream.Launcher.Core.Tests/Profiles/LauncherProfileTextTests.cs
@@ -4,21 +4,36 @@ namespace AcDream.Launcher.Core.Tests.Profiles;
 
 public sealed class LauncherProfileTextTests
 {
+    [Fact]
+    public void UsersSurviveNoServersAndPopulateEveryServerAddedLater()
+    {
+        var document = new LauncherProfileDocument();
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, "Alice | one\nBob | two");
+        Assert.Equal(2, document.Users!.Count);
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Servers, "One | localhost | 9000\nTwo | localhost | 9001");
+        Assert.All(document.Servers, server => Assert.Equal(new[] { "Alice", "Bob" }, server.Accounts.Select(account => account.Account)));
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Servers, "");
+        Assert.Contains("Alice | one", LauncherProfileText.Read(document, LauncherTextEditorKind.Users));
+        LauncherProfileText.Apply(document, LauncherTextEditorKind.Servers, "Three | localhost | 9002");
+        Assert.Equal(2, document.Servers[0].Accounts.Count);
+        Assert.DoesNotContain("Three", LauncherProfileText.Read(document, LauncherTextEditorKind.Users));
+    }
+
     private static LauncherProfileDocument Sample() => new()
     {
         Servers = [new() { Name = "One", Host = "localhost", Port = 9000,
             Accounts = [new() { Account = "User", Password = "first", Characters = [new() { Name = "Hero", Id = "0x50000001", LaunchMode = LaunchMode.Headless, Plugins = ["plugin"], LoginCommands = ["/help"] }] }] },
-            new() { Name = "Two", Host = "localhost", Port = 9001, Accounts = [new() { Account = "User", Password = "second" }] }],
+            new() { Name = "Two", Host = "localhost", Port = 9001, Accounts = [new() { Account = "User", Password = "first" }] }],
     };
 
     [Fact]
-    public void UserRoundTripPreservesDistinctCredentialsAndCharacterSettings()
+    public void UserRoundTripPreservesSharedCredentialsAndCharacterSettings()
     {
         var document = Sample();
         string text = LauncherProfileText.Read(document, LauncherTextEditorKind.Users);
         LauncherProfileText.Apply(document, LauncherTextEditorKind.Users, text);
         Assert.Equal("first", document.Servers[0].Accounts[0].Password);
-        Assert.Equal("second", document.Servers[1].Accounts[0].Password);
+        Assert.Equal("first", document.Servers[1].Accounts[0].Password);
         var character = document.Servers[0].Accounts[0].Characters[0];
         Assert.Equal(LaunchMode.Headless, character.LaunchMode);
         Assert.Equal(["plugin"], character.Plugins);
@@ -60,7 +75,7 @@ public sealed class LauncherProfileTextTests
             store.AddServer("One", "localhost", 9000);
             store.AddAccount("One", "Original", "original-password");
             var error = Record.Exception(() => store.ExecuteTransaction(() => LauncherProfileText.Apply(store.Document,
-                LauncherTextEditorKind.Users, "New | new-password | One")));
+                LauncherTextEditorKind.Users, "New | new-password")));
             Assert.True(error is IOException or UnauthorizedAccessException);
             Assert.Equal("Original", store.Document.Servers[0].Accounts[0].Account);
             Assert.Equal("original-password", store.Document.Servers[0].Accounts[0].Password);

--- a/tests/AcDream.Launcher.Core.Tests/Status/ServerHealthServiceTests.cs
+++ b/tests/AcDream.Launcher.Core.Tests/Status/ServerHealthServiceTests.cs
@@ -8,6 +8,16 @@ namespace AcDream.Launcher.Core.Tests.Status;
 public sealed class ServerHealthServiceTests
 {
     [Fact]
+    public void PopulationMatchesHostnameWhenDisplayNameIsAnAddress()
+    {
+        var counts = ServerHealthService.ParsePlayerCounts("""[{"server":"Coldeve","count":807}]""");
+        Assert.Equal(807, ServerHealthService.FindPlayerCount(counts, "play.coldeve.ac", "play.coldeve.ac"));
+        Assert.Equal(807, ServerHealthService.FindPlayerCount(counts, "My favourite", "play.coldeve.ac"));
+        Assert.Null(ServerHealthService.FindPlayerCount(counts, "Local", "localhost"));
+        Assert.Null(ServerHealthService.FindPlayerCount(counts, "Another", "notcoldeve.example"));
+    }
+
+    [Fact]
     public async Task UdpProbeUsesPasswordlessStatusIdentityAndWaitsForValidReply()
     {
         using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
@@ -43,7 +53,7 @@ public sealed class ServerHealthServiceTests
     }
 
     [Fact]
-    public async Task FailedRefreshMarksPreviousCountStaleAndNoReplyUnknown()
+    public async Task FailedRefreshMarksPreviousCountStaleAndNoReplyOffline()
     {
         var time = new TestClock();
         var handler = new ResponseHandler();
@@ -56,7 +66,7 @@ public sealed class ServerHealthServiceTests
         var stale = await service.CheckAsync("localhost", 9000, "Busy");
         Assert.Equal(27, stale.PlayerCount);
         Assert.True(stale.IsPlayerCountStale);
-        Assert.Null(stale.IsReachable);
+        Assert.False(stale.IsReachable);
     }
 
     [Fact]

--- a/tests/AcDream.Launcher.Core.Tests/Status/ServerHealthServiceTests.cs
+++ b/tests/AcDream.Launcher.Core.Tests/Status/ServerHealthServiceTests.cs
@@ -1,0 +1,123 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using AcDream.Launcher.Core.Status;
+
+namespace AcDream.Launcher.Core.Tests.Status;
+
+public sealed class ServerHealthServiceTests
+{
+    [Fact]
+    public async Task UdpProbeUsesPasswordlessStatusIdentityAndWaitsForValidReply()
+    {
+        using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        int port = ((IPEndPoint)server.Client.LocalEndPoint!).Port;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        Task<double?> pending = new UdpServerReachabilityProbe().ProbeAsync("127.0.0.1", port, timeout.Token);
+        var request = await server.ReceiveAsync(timeout.Token);
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(request.Buffer.AsSpan(32)));
+        Assert.Equal("acservertracker:jj9h26hcsggc", System.Text.Encoding.ASCII.GetString(request.Buffer, 46, 28));
+        await server.SendAsync(new byte[] { 1, 2, 3 }, request.RemoteEndPoint, timeout.Token);
+        var response = new byte[52];
+        BinaryPrimitives.WriteUInt32LittleEndian(response.AsSpan(4), 0x40000);
+        BinaryPrimitives.WriteUInt16LittleEndian(response.AsSpan(16), 32);
+        await server.SendAsync(response, request.RemoteEndPoint, timeout.Token);
+        Assert.NotNull(await pending);
+    }
+
+    [Fact]
+    public async Task SharesPopulationFetchAndPreservesZeroAndMissingCounts()
+    {
+        var handler = new ResponseHandler();
+        using var http = new HttpClient(handler);
+        var service = new ServerHealthService(http, new FixedProbe());
+        var snapshots = await Task.WhenAll(
+            service.CheckAsync("localhost", 9000, "Empty"),
+            service.CheckAsync("localhost", 9000, "Unknown"),
+            service.CheckAsync("localhost", 9000, "Busy"));
+        Assert.Equal(1, handler.Requests);
+        Assert.Equal(0, snapshots[0].PlayerCount);
+        Assert.Null(snapshots[1].PlayerCount);
+        Assert.Equal(27, snapshots[2].PlayerCount);
+        Assert.All(snapshots, snapshot => Assert.True(snapshot.IsReachable));
+    }
+
+    [Fact]
+    public async Task FailedRefreshMarksPreviousCountStaleAndNoReplyUnknown()
+    {
+        var time = new TestClock();
+        var handler = new ResponseHandler();
+        using var http = new HttpClient(handler);
+        var service = new ServerHealthService(http, new FixedProbe(null), time);
+        var first = await service.CheckAsync("localhost", 9000, "Busy");
+        Assert.False(first.IsPlayerCountStale);
+        time.Now += TimeSpan.FromMinutes(2);
+        handler.Fail = true;
+        var stale = await service.CheckAsync("localhost", 9000, "Busy");
+        Assert.Equal(27, stale.PlayerCount);
+        Assert.True(stale.IsPlayerCountStale);
+        Assert.Null(stale.IsReachable);
+    }
+
+    [Fact]
+    public async Task CallerCancellationPropagates()
+    {
+        using var http = new HttpClient(new ResponseHandler());
+        var service = new ServerHealthService(http, new FixedProbe());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.CheckAsync("localhost", 9000, "Busy", cancellation.Token));
+    }
+
+    [Fact]
+    public void IgnoresInvalidPopulationValues()
+    {
+        var counts = ServerHealthService.ParsePlayerCounts("""
+            [{"server":"Empty","count":0},{"server":"Bad","count":-1},
+             {"server":"String","count":"12"},{"server":"Overflow","count":99999999999},null]
+            """);
+        Assert.Single(counts);
+        Assert.Equal(0, counts["empty"]);
+    }
+
+    [Fact]
+    public void AcceptsChallengeAndRejectsTruncatedOrUnrelatedDatagrams()
+    {
+        var packet = new byte[52];
+        BinaryPrimitives.WriteUInt32LittleEndian(packet.AsSpan(4), 0x40000);
+        BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(16), 32);
+        Assert.True(UdpServerReachabilityProbe.IsStatusReply(packet));
+        Assert.False(UdpServerReachabilityProbe.IsStatusReply(packet.AsSpan(0, 24)));
+        packet[4] = 4;
+        Assert.False(UdpServerReachabilityProbe.IsStatusReply(packet));
+        Assert.False(UdpServerReachabilityProbe.IsStatusReply([1, 2, 3]));
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = DateTimeOffset.UtcNow;
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private sealed class FixedProbe(double? latency = 12) : IServerReachabilityProbe
+    {
+        public Task<double?> ProbeAsync(string host, int port, CancellationToken cancellationToken)
+            => Task.FromResult(latency);
+    }
+
+    private sealed class ResponseHandler : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+        public bool Fail { get; set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests++;
+            if (Fail) throw new HttpRequestException("Unavailable");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""[{"server":"Empty","count":0},{"server":"Busy","count":27}]"""),
+            });
+        }
+    }
+}

--- a/tests/AcDream.Launcher.Tests/LauncherProjectBoundaryTests.cs
+++ b/tests/AcDream.Launcher.Tests/LauncherProjectBoundaryTests.cs
@@ -118,8 +118,8 @@ public sealed class LauncherProjectBoundaryTests
             "AcDream.Launcher",
             "MainWindow.axaml.cs"));
 
-        Assert.Equal(3, Count(markup, "KeyboardNavigation.TabNavigation=\"Cycle\""));
-        Assert.Equal(3, Count(markup, "KeyDown=\"OnModalKeyDown\""));
+        Assert.Equal(6, Count(markup, "KeyboardNavigation.TabNavigation=\"Cycle\""));
+        Assert.Equal(6, Count(markup, "KeyDown=\"OnModalKeyDown\""));
         Assert.True(Count(markup, "AutomationProperties.Name=") >= 13);
         Assert.True(Count(markup, "IsDefault=\"True\"") >= 3);
         Assert.True(Count(markup, "IsCancel=\"True\"") >= 3);

--- a/tests/AcDream.Launcher.Tests/LauncherUpdateViewModelTests.cs
+++ b/tests/AcDream.Launcher.Tests/LauncherUpdateViewModelTests.cs
@@ -6,6 +6,38 @@ namespace AcDream.Launcher.Tests;
 public sealed class LauncherUpdateViewModelTests
 {
     [Fact]
+    public async Task BannerModeDefersModalUntilReviewAndClearsAvailabilityAfterInstall()
+    {
+        var updater = new FakeUpdater { ClientUpdateAvailable = true };
+        using var vm = Create(updater);
+        vm.AutoOpenDiscoveredUpdates = false;
+        await vm.StartupCheckAsync();
+        Assert.True(vm.IsClientUpdateAvailable);
+        Assert.False(vm.IsOpen);
+        vm.OpenAvailableUpdate();
+        Assert.True(vm.IsOpen);
+        await vm.UpdateCommand.ExecuteAsync();
+        Assert.False(vm.IsClientUpdateAvailable);
+        Assert.False(vm.IsOpen);
+    }
+
+    [Fact]
+    public async Task SuccessfulManualRetryReplacesPreviousFailureStatus()
+    {
+        var updater = new FakeUpdater
+        {
+            CheckHandler = _ => Task.FromException<LauncherUpdateCheckResult>(new IOException("Offline")),
+        };
+        using var vm = Create(updater);
+        await vm.StartupCheckAsync();
+        Assert.Contains("could not", vm.Status);
+        updater.CheckHandler = null;
+        await vm.StartupCheckAsync();
+        Assert.True(vm.StartupCheckSucceeded);
+        Assert.Contains("up to date", vm.Status);
+    }
+
+    [Fact]
     public async Task NothingOutOfDateNeverShowsTheDialog()
     {
         var updater = new FakeUpdater
@@ -222,7 +254,7 @@ public sealed class LauncherUpdateViewModelTests
         public Func<CancellationToken, Task<LauncherUpdateCheckResult>>? CheckHandler
         {
             get;
-            init;
+            set;
         }
 
         public Func<

--- a/tests/AcDream.Launcher.Tests/LauncherWindowViewModel.Accounts.Tests.cs
+++ b/tests/AcDream.Launcher.Tests/LauncherWindowViewModel.Accounts.Tests.cs
@@ -6,6 +6,47 @@ namespace AcDream.Launcher.Tests;
 
 public sealed partial class LauncherWindowViewModelTests
 {
+    [Fact]
+    public async Task PollRefreshesPlayWhenReconnectDelayExpiresWithoutAnEvent()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        var row = vm.Accounts[0].Servers[0];
+        core.AccountLaunchCapability = LauncherCapability.Unavailable("Try again in 1 s.");
+        vm.PollStatus();
+        Assert.False(row.PlayCommand.CanExecute(null));
+        int notifications = 0;
+        row.PlayCommand.CanExecuteChanged += (_, _) => notifications++;
+        core.AccountLaunchCapability = LauncherCapability.Available;
+        vm.PollStatus();
+        Assert.True(notifications > 0);
+        Assert.True(row.PlayCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task FailedStartupIsShownInItsRowAndNotCountedAsStarted()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        var row = vm.Accounts[0].Servers[0];
+        core.LaunchHandler = _ =>
+        {
+            core.Session = core.Session with { ServerName = row.ServerName, AccountName = row.AccountName,
+                State = LauncherActivityState.Failed, Error = "Client files do not match", ExitCode = 1 };
+            return Task.FromResult(core.Session);
+        };
+        await row.PlayCommand.ExecuteAsync();
+        Assert.Contains("Started 0 of 1", vm.OperationStatus);
+        Assert.Equal("Client files do not match", row.LaunchError);
+        Assert.True(row.HasLaunchError);
+        Assert.False(row.IsActive);
+        Assert.True(row.PlayCommand.CanExecute(null));
+    }
+
     private static LauncherServerSnapshot BatchServer(string name, params string[] accounts) => new(name, "localhost", 9000,
         accounts.Select(account => new LauncherAccountSnapshot(name, account,
             [new LauncherCharacterSnapshot(name, account, "A character", "123", LaunchMode.Gui, [], [], false, "Ready")], false, "Ready")).ToArray());

--- a/tests/AcDream.Launcher.Tests/LauncherWindowViewModel.Accounts.Tests.cs
+++ b/tests/AcDream.Launcher.Tests/LauncherWindowViewModel.Accounts.Tests.cs
@@ -1,0 +1,155 @@
+using AcDream.Launcher.Core.Orchestration;
+using AcDream.Launcher.Core.Profiles;
+using AcDream.Launcher.ViewModels;
+
+namespace AcDream.Launcher.Tests;
+
+public sealed partial class LauncherWindowViewModelTests
+{
+    private static LauncherServerSnapshot BatchServer(string name, params string[] accounts) => new(name, "localhost", 9000,
+        accounts.Select(account => new LauncherAccountSnapshot(name, account,
+            [new LauncherCharacterSnapshot(name, account, "A character", "123", LaunchMode.Gui, [], [], false, "Ready")], false, "Ready")).ToArray());
+
+    private static FakeLauncherOrchestrator BatchOrchestrator() => new()
+    {
+        ServersOverride = [BatchServer("One", "Alice", "Bob"), BatchServer("Two", "Alice")],
+        Session = FakeLauncherOrchestrator.CreateSession(LauncherActivityState.Exited),
+    };
+
+    [Fact]
+    public void ChangingEndpointClearsHealthFromTheOldEndpoint()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        var row = vm.Accounts[0].Servers[0];
+        row.IsServerOnline = true;
+        row.ServerStatusText = "Online · 12 players";
+        core.ServersOverride = core.ServersOverride!.Select(server => server with { Host = "different.example" }).ToArray();
+        core.RaiseStateChanged();
+        Assert.Null(row.IsServerOnline);
+        Assert.Equal("Not checked", row.ServerStatusText);
+    }
+
+    [Fact]
+    public async Task CheckedRowsLaunchAllSelectedAccountsWithRequestedModesAndContinueAfterFailure()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        LauncherAccountServerRowViewModel[] rows = vm.Accounts.SelectMany(account => account.Servers).ToArray();
+        foreach (var row in rows) row.IsChecked = true;
+        rows[1].SelectedCharacter = "A character";
+        rows[1].SelectedLaunchMode = "Headless";
+        int calls = 0;
+        core.LaunchHandler = _ => ++calls == 1 ? throw new LauncherOperationException("Failed to start") : Task.FromResult(core.Session);
+        await vm.LaunchCheckedCommand.ExecuteAsync();
+        Assert.Equal(3, core.LaunchRequests.Count);
+        Assert.Equal(LaunchMode.GuiSelect, core.LaunchRequests[0].Mode);
+        Assert.Null(core.LaunchRequests[0].Character);
+        Assert.Equal(LaunchMode.Headless, core.LaunchRequests[1].Mode);
+        Assert.Equal("A character", core.LaunchRequests[1].Character);
+        Assert.Contains("Started 2 of 3", vm.OperationStatus);
+        Assert.Contains("Failed to start", vm.LastError);
+    }
+
+    [Fact]
+    public async Task PollingPreservesChecksCharactersAndExpansionAndBatchCannotDoubleStart()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        var group = vm.Accounts[0];
+        var row = group.Servers[0];
+        group.IsExpanded = false;
+        row.IsChecked = true;
+        row.SelectedCharacter = "A character";
+        core.RaiseStateChanged();
+        Assert.Same(group, vm.Accounts[0]);
+        Assert.Same(row, group.Servers[0]);
+        Assert.False(group.IsExpanded);
+        Assert.True(row.IsChecked);
+        Assert.Equal("A character", row.SelectedCharacter);
+        var pending = new TaskCompletionSource<LauncherSessionSnapshot>();
+        core.LaunchHandler = _ => pending.Task;
+        Task launching = vm.LaunchCheckedCommand.ExecuteAsync();
+        core.RaiseStateChanged();
+        await vm.LaunchCheckedCommand.ExecuteAsync();
+        await row.PlayCommand.ExecuteAsync();
+        Assert.Single(core.LaunchRequests);
+        pending.SetResult(core.Session);
+        await launching;
+    }
+
+    [Fact]
+    public async Task MixedCheckedRowsReportInvalidSelectionWithoutDroppingReadyLaunches()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        var rows = vm.Accounts[0].Servers;
+        rows[0].IsChecked = true;
+        rows[1].IsChecked = true;
+        rows[1].SelectedLaunchMode = "Headless";
+        await vm.LaunchCheckedCommand.ExecuteAsync();
+        Assert.Single(core.LaunchRequests);
+        Assert.Contains("Choose a character", vm.LastError);
+        Assert.Contains("Started 1 of 2", vm.OperationStatus);
+    }
+    [Fact]
+    public void RosterRefreshKeepsChosenCharacterWhenSelectorTemporarilyClearsBinding()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        var row = vm.Accounts[0].Servers[0];
+        row.SelectedCharacter = "A character";
+        row.CharacterChoices.CollectionChanged += (_, _) => row.SelectedCharacter = null!;
+        var server = core.ServersOverride![0];
+        var account = server.Accounts[0];
+        core.ServersOverride = [server with { Accounts = [account with
+        {
+            Characters = [.. account.Characters, account.Characters[0] with { Name = "Another character" }],
+        }, server.Accounts[1]] }, core.ServersOverride[1]];
+        core.RaiseStateChanged();
+        Assert.Equal("A character", row.SelectedCharacter);
+        Assert.Contains("Another character", row.CharacterChoices);
+    }
+
+    [Fact]
+    public async Task ClosingDuringBatchCancelsRemainingLaunchesWithoutReadingDisposedCancellationSource()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        foreach (var row in vm.Accounts[0].Servers) row.IsChecked = true;
+        var pending = new TaskCompletionSource<LauncherSessionSnapshot>();
+        core.LaunchHandler = _ => pending.Task;
+        Task launching = vm.LaunchCheckedCommand.ExecuteAsync();
+        vm.Dispose();
+        pending.SetResult(core.Session);
+        await launching;
+        Assert.Single(core.LaunchRequests);
+    }
+    [Fact]
+    public async Task HeadlessRequiresCharacterAndFreshActiveStateBlocksStaleRowLaunch()
+    {
+        using var core = BatchOrchestrator();
+        using var vm = CreateInitialized(core);
+        await vm.StartBackgroundInitializationAsync();
+        vm.CloseActiveModal();
+        var row = vm.Accounts[0].Servers[0];
+        row.IsChecked = true;
+        row.SelectedLaunchMode = "Headless";
+        Assert.False(row.CanPlay);
+        Assert.Contains("Choose a character", row.DisabledReason);
+        row.SelectedCharacter = "A character";
+        Assert.True(row.CanPlay);
+        core.Session = core.Session with { ServerName = row.ServerName, AccountName = row.AccountName, State = LauncherActivityState.Running };
+        Assert.False(row.PlayCommand.CanExecute(null));
+        await vm.LaunchCheckedCommand.ExecuteAsync();
+        Assert.Empty(core.LaunchRequests);
+    }
+}

--- a/tests/AcDream.Launcher.Tests/LauncherWindowViewModelTests.cs
+++ b/tests/AcDream.Launcher.Tests/LauncherWindowViewModelTests.cs
@@ -7,7 +7,7 @@ using AcDream.Launcher.ViewModels;
 
 namespace AcDream.Launcher.Tests;
 
-public sealed class LauncherWindowViewModelTests
+public sealed partial class LauncherWindowViewModelTests
 {
     [Fact]
     public async Task InitializeProjectsHierarchySessionsAndFutureWorkflowShells()
@@ -40,7 +40,7 @@ public sealed class LauncherWindowViewModelTests
         await viewModel.StartBackgroundInitializationAsync();
         Assert.False(viewModel.IsInstallationChecking);
         Assert.True(viewModel.IsFirstRunRequired);
-        Assert.Contains("SHA-256", viewModel.FirstRunWizardShell.Body, StringComparison.Ordinal);
+        Assert.Contains("Build and install", viewModel.FirstRunWizardShell.Body, StringComparison.Ordinal);
         Assert.False(viewModel.UpdatePrompt.IsOpen);
         Assert.Empty(viewModel.UpdatePrompt.Body);
         viewModel.FirstRunWizardShell.OpenCommand.Execute(null);
@@ -927,6 +927,8 @@ public sealed class LauncherWindowViewModelTests
     {
         public event EventHandler? StateChanged;
 
+        public IReadOnlyList<LauncherServerSnapshot>? ServersOverride { get; set; }
+        public List<(string Server, string Account, string? Character, LaunchMode Mode)> LaunchRequests { get; } = [];
         public bool LoadCalled { get; private set; }
 
         public bool ClearCalled { get; private set; }
@@ -983,7 +985,7 @@ public sealed class LauncherWindowViewModelTests
         public void LoadProfiles() => LoadCalled = true;
 
         public LauncherStateSnapshot GetSnapshot() => new(
-            [CreateServerSnapshot()],
+            ServersOverride ?? [CreateServerSnapshot()],
             [Session],
             Platform,
             IsInstallationReady: InstalledRecord is not null,
@@ -1083,6 +1085,7 @@ public sealed class LauncherWindowViewModelTests
             CancellationToken cancellationToken = default)
         {
             LaunchRequest = (serverName, accountName, characterName, mode);
+            LaunchRequests.Add(LaunchRequest.Value);
             return LaunchHandler?.Invoke(cancellationToken) ?? Task.FromResult(Session);
         }
 

--- a/tests/AcDream.Launcher.Tests/MainWindowViewTests.cs
+++ b/tests/AcDream.Launcher.Tests/MainWindowViewTests.cs
@@ -5,8 +5,10 @@ using AcDream.Launcher.Core.Launching;
 using AcDream.Launcher.Core.Orchestration;
 using AcDream.Launcher.Core.Profiles;
 using AcDream.Launcher.ViewModels;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Headless;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
@@ -16,7 +18,11 @@ public sealed class MainWindowViewTests
 {
     private static readonly (string Name, Type Type)[] ExpectedNamedControls =
     [
-        ("ProfilesTree", typeof(TreeView)),
+        ("AccountsScroll", typeof(ScrollViewer)),
+        ("PlayCheckedButton", typeof(Button)),
+        ("ProfileTextBox", typeof(TextBox)),
+        ("CharacterPluginsTextBox", typeof(TextBox)),
+        ("SessionLogCloseButton", typeof(Button)),
         ("ServerNameTextBox", typeof(TextBox)),
         ("AccountNameTextBox", typeof(TextBox)),
         ("CharacterNameTextBox", typeof(TextBox)),
@@ -36,6 +42,7 @@ public sealed class MainWindowViewTests
         OpeningAndClosingTheFirstRunWizardFocusesAndRunsTheCloseFallbackWithoutThrowing();
         await OpeningAndClosingTheUpdatePromptFocusesAndRunsTheCloseFallbackWithoutThrowing();
         ClosingAModalRestoresThePreviouslyFocusedControlWithoutThrowing();
+        ResizingKeepsBatchActionsVisibleWhileManyAccountsScroll();
     }
 
     private static void EveryExplicitlyNamedControlIsAssignedAfterConstruction()
@@ -200,7 +207,7 @@ public sealed class MainWindowViewTests
             Control addServerButton = window
                 .GetVisualDescendants()
                 .OfType<Button>()
-                .First(button => Equals(button.Content, "+ Server"));
+                .First(button => Equals(button.Content, "Edit Servers"));
             addServerButton.Focus();
             Assert.Same(addServerButton, CurrentFocus(window));
 
@@ -214,13 +221,58 @@ public sealed class MainWindowViewTests
 
             // addServerButton was focused before the dialog opened, so the
             // restore branch (focusToRestore.Focus()) is what ran here, not
-            // the ProfilesTree.Focus() fallback exercised by the tests above.
+            // the account list focus fallback exercised by the tests above.
             Assert.Same(addServerButton, CurrentFocus(window));
         }
         finally
         {
             CloseTestWindow(window);
         }
+    }
+
+    private static void ResizingKeepsBatchActionsVisibleWhileManyAccountsScroll()
+    {
+        var source = new StubOrchestrator
+        {
+            ServerRows = [new LauncherServerSnapshot("Local", "127.0.0.1", 9000,
+                Enumerable.Range(1, 30).Select(i => new LauncherAccountSnapshot("Local", $"account{i}",
+                    [new LauncherCharacterSnapshot("Local", $"account{i}", $"Character{i}", "0x50000001",
+                        LaunchMode.Gui, [], [], false, "Ready")], false, "Ready")).ToArray())],
+        };
+        using var model = new LauncherWindowViewModel(source, new ImmediateUiDispatcher());
+        model.Initialize();
+        var window = new MainWindow { DataContext = model };
+        try
+        {
+            window.Show();
+            Assert.True(window.CanResize);
+            foreach (var size in new[] { new Avalonia.Size(760, 460), new Avalonia.Size(1120, 740), new Avalonia.Size(1600, 1000) })
+            {
+                window.Width = size.Width;
+                window.Height = size.Height;
+                window.UpdateLayout();
+                Dispatcher.UIThread.RunJobs();
+                var scroll = window.FindControl<ScrollViewer>("AccountsScroll")!;
+                var play = window.FindControl<Button>("PlayCheckedButton")!;
+                Assert.True(scroll.Bounds.Height > 50);
+                Assert.True(scroll.Extent.Height > scroll.Viewport.Height);
+                Avalonia.Point origin = play.TranslatePoint(default, window)!.Value;
+                Assert.InRange(origin.X, 0, window.Bounds.Width - play.Bounds.Width + 1);
+                Assert.InRange(origin.Y, 0, window.Bounds.Height - play.Bounds.Height + 1);
+                Assert.Equal(30, model.Accounts.Count);
+                string artifacts = Path.Combine(FindRepositoryRoot(), "artifacts", "launcher-redesign");
+                Directory.CreateDirectory(artifacts);
+                AvaloniaHeadlessPlatform.ForceRenderTimerTick(1);
+                using var frame = window.CaptureRenderedFrame();
+                Assert.NotNull(frame);
+                frame.Save(Path.Combine(artifacts, $"launcher-{size.Width:0}x{size.Height:0}.png"), Avalonia.Media.Imaging.PngBitmapEncoderOptions.Default);
+            }
+            model.OpenSessionLogCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Same(window.FindControl<Button>("SessionLogCloseButton"), CurrentFocus(window));
+            model.CloseActiveModal();
+        }
+        finally { CloseTestWindow(window); }
     }
 
     private static void CloseTestWindow(MainWindow window)
@@ -402,6 +454,7 @@ public sealed class MainWindowViewTests
 
     private sealed class StubOrchestrator : ILauncherOrchestrator
     {
+        public IReadOnlyList<LauncherServerSnapshot> ServerRows { get; set; } = [];
         // Never raised: these tests exercise MainWindow's dispatcher/focus
         // wiring directly and never trigger an orchestrator-side refresh.
 #pragma warning disable CS0067
@@ -413,7 +466,7 @@ public sealed class MainWindowViewTests
         }
 
         public LauncherStateSnapshot GetSnapshot() => new(
-            Servers: [],
+            Servers: ServerRows,
             Sessions: [],
             Platform: LauncherPlatformCapabilities.Detect(),
             IsInstallationReady: false,

--- a/tests/AcDream.Launcher.Tests/TestAppBuilder.cs
+++ b/tests/AcDream.Launcher.Tests/TestAppBuilder.cs
@@ -13,5 +13,6 @@ public static class TestAppBuilder
 {
     public static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<App>()
-            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
 }


### PR DESCRIPTION
The launcher now presents a compact account list with multiple servers per account, character selection, Graphical/Headless mode, per-row Play/Stop and checked batch launching. The resizable window keeps launch controls visible while large account lists scroll.

Adds OpenAC branding and the approved charcoal/amber styling; built-in user/server editors with atomic saves; per-character plugin/logon options; bounded endpoint status checks and externally reported player counts; and an update banner with explicit review. Existing profile storage, supervised sessions, installation verification and content/update barriers remain authoritative.

Validation: Release solution build and comment-residue gate pass; 379 filtered launcher-core tests and 95 launcher regression tests pass; the isolated Avalonia window test renders 30 accounts at 760×460, 1120×740 and 1600×1000 and verifies visible batch controls, scrolling and modal focus. Linux runtime interaction and live multi-account visual acceptance remain pending.
