### PR TITLE
Add macOS (Apple silicon) support for the graphical client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ players help us decide what to fix next.
 **Platforms.** Windows and Linux, 64-bit, for the launcher, the graphical
 client, and the headless host. Windows is where most of the play-testing
 happens; the Linux client is newer and has had less time in front of players,
-so reports from Linux desktops are especially welcome. macOS support for
-Apple silicon is on the roadmap.
+so reports from Linux desktops are especially welcome. macOS on Apple
+silicon runs the graphical client, built from source; the launcher does not
+support it yet.
 
 ## Roadmap
 
 - **Linux in CI.** The Linux graphical client builds, installs through the
   launcher, and plays, but CI runs its rendering tests on Windows hardware
   only. A Linux rendering lane is next.
-- **macOS on Apple silicon.**
+- **macOS in the launcher and CI.** The graphical client builds, renders
+  through MoltenVK, and plays on Apple silicon. The launcher does not run
+  there yet, and no CI lane covers it.
 - **Performance tuning.** Improve frame times, world streaming, memory use,
   and responsiveness.
 - **Housing.**

--- a/docs/building-and-running.md
+++ b/docs/building-and-running.md
@@ -10,10 +10,16 @@
   at `127.0.0.1:9000`.
 - For the graphical client, a **Vulkan 1.3** capable GPU and driver. On
   Linux that means your distribution's Vulkan ICD for your GPU (for example
-  `mesa-vulkan-drivers` on Ubuntu) and an X11 or Wayland desktop.
+  `mesa-vulkan-drivers` on Ubuntu) and an X11 or Wayland desktop. On macOS it
+  means MoltenVK and the Vulkan loader (`brew install molten-vk
+  vulkan-loader`); MoltenVK is reached through
+  `VK_KHR_portability_enumeration`, and the loader needs
+  `VK_ICD_FILENAMES=$(brew --prefix)/etc/vulkan/icd.d/MoltenVK_icd.json`.
 
-Windows and Linux (x64) are both supported. The examples below use
-PowerShell; the bash equivalents differ only in how variables are set.
+Windows and Linux (x64) are both supported, and macOS (arm64) runs the
+graphical client and the bake step from source; the launcher is Windows and
+Linux only. The examples below use PowerShell; the bash equivalents differ
+only in how variables are set.
 
 ## Build and test
 

--- a/src/AcDream.App/Platform/GraphicalHostPlatformServices.cs
+++ b/src/AcDream.App/Platform/GraphicalHostPlatformServices.cs
@@ -9,12 +9,16 @@ internal enum GraphicalHostOperatingSystem
 {
     Windows,
     Linux,
+    MacOS,
 }
 
 internal static class RuntimePlatformGuard
 {
     [SupportedOSPlatformGuard("linux")]
     internal static bool IsLinuxRuntime => System.OperatingSystem.IsLinux();
+
+    [SupportedOSPlatformGuard("macos")]
+    internal static bool IsMacOsRuntime => System.OperatingSystem.IsMacOS();
 }
 
 internal sealed record GraphicalNativeDependency(
@@ -60,9 +64,11 @@ internal sealed record GraphicalHostPlatformServices(
             return GraphicalHostOperatingSystem.Windows;
         if (System.OperatingSystem.IsLinux())
             return GraphicalHostOperatingSystem.Linux;
+        if (System.OperatingSystem.IsMacOS())
+            return GraphicalHostOperatingSystem.MacOS;
 
         throw new PlatformNotSupportedException(
-            "acdream graphical hosting supports Windows and Linux.");
+            "acdream graphical hosting supports Windows, Linux, and macOS.");
     }
 
     private static string ResolveRuntimeIdentifier(
@@ -86,10 +92,14 @@ internal sealed record GraphicalHostPlatformServices(
                 "The first acdream Linux graphical package supports linux-x64 only.");
         }
 
-        string operatingSystemName =
-            operatingSystem == GraphicalHostOperatingSystem.Windows
-                ? "win"
-                : "linux";
+        string operatingSystemName = operatingSystem switch
+        {
+            GraphicalHostOperatingSystem.Windows => "win",
+            GraphicalHostOperatingSystem.Linux => "linux",
+            GraphicalHostOperatingSystem.MacOS => "osx",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(operatingSystem)),
+        };
         return $"{operatingSystemName}-{architectureName}";
     }
 
@@ -107,6 +117,11 @@ internal sealed record GraphicalHostPlatformServices(
             [
                 new("window/input", "libglfw.so.3"),
                 new("audio", "libopenal.so"),
+            ],
+            GraphicalHostOperatingSystem.MacOS =>
+            [
+                new("window/input", "libglfw.3.dylib"),
+                new("audio", "libopenal.dylib"),
             ],
             _ => throw new ArgumentOutOfRangeException(
                 nameof(operatingSystem)),

--- a/src/AcDream.App/Platform/GraphicalWindowBackendSelection.cs
+++ b/src/AcDream.App/Platform/GraphicalWindowBackendSelection.cs
@@ -10,6 +10,7 @@ internal enum GraphicalDisplayProtocol
     Windows,
     X11,
     Wayland,
+    Cocoa,
     Automatic,
 }
 
@@ -36,6 +37,15 @@ internal sealed record GraphicalWindowBackendSelection(
             return new(
                 GraphicalDisplayProtocol.Windows,
                 "Windows graphical host");
+        }
+
+        if (operatingSystem == GraphicalHostOperatingSystem.MacOS)
+        {
+            // GLFW exposes exactly one native backend on macOS, so the
+            // X11/Wayland selection below has nothing to choose between.
+            return new(
+                GraphicalDisplayProtocol.Cocoa,
+                "macOS graphical host");
         }
 
         string? configured = environment(EnvironmentVariable);
@@ -97,6 +107,7 @@ internal static class GraphicalWindowBackendConfigurator
     private const int GlfwPlatformInitHint = 0x00050003;
     private const int GlfwAnyPlatform = 0x00060000;
     private const int GlfwWin32Platform = 0x00060001;
+    private const int GlfwCocoaPlatform = 0x00060002;
     private const int GlfwWaylandPlatform = 0x00060003;
     private const int GlfwX11Platform = 0x00060004;
 
@@ -141,6 +152,8 @@ internal static class GraphicalWindowBackendConfigurator
                         GlfwX11Platform,
                     GraphicalDisplayProtocol.Wayland =>
                         GlfwWaylandPlatform,
+                    GraphicalDisplayProtocol.Cocoa =>
+                        GlfwCocoaPlatform,
                     GraphicalDisplayProtocol.Automatic =>
                         GlfwAnyPlatform,
                     _ => throw new ArgumentOutOfRangeException(
@@ -182,6 +195,7 @@ internal static class GraphicalWindowBackendConfigurator
 internal static unsafe class GlfwNativePlatformProbe
 {
     private const int GlfwWin32Platform = 0x00060001;
+    private const int GlfwCocoaPlatform = 0x00060002;
     private const int GlfwWaylandPlatform = 0x00060003;
     private const int GlfwX11Platform = 0x00060004;
 
@@ -190,6 +204,8 @@ internal static unsafe class GlfwNativePlatformProbe
     {
         if (operatingSystem == GraphicalHostOperatingSystem.Windows)
             return GraphicalDisplayProtocol.Windows;
+        if (operatingSystem == GraphicalHostOperatingSystem.MacOS)
+            return GraphicalDisplayProtocol.Cocoa;
 
         if (!GraphicalWindowBackendConfigurator.TryGetConfiguredApi(
                 out Glfw? glfw)
@@ -208,6 +224,7 @@ internal static unsafe class GlfwNativePlatformProbe
             GlfwX11Platform => GraphicalDisplayProtocol.X11,
             GlfwWaylandPlatform => GraphicalDisplayProtocol.Wayland,
             GlfwWin32Platform => GraphicalDisplayProtocol.Windows,
+            GlfwCocoaPlatform => GraphicalDisplayProtocol.Cocoa,
             _ => GraphicalDisplayProtocol.Unknown,
         };
     }

--- a/src/AcDream.App/Rendering/BitmapFont.cs
+++ b/src/AcDream.App/Rendering/BitmapFont.cs
@@ -152,6 +152,11 @@ public sealed unsafe class BitmapFont : IDisposable
             @"C:\Windows\Fonts\arial.ttf",
             "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
             "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
+            // macOS ships Menlo only as a .ttc collection, whose first font
+            // does not start at offset 0; stbtt_InitFont rejects it. Prefer
+            // the plain .ttf faces and keep the collections as a last resort.
+            "/System/Library/Fonts/SFNSMono.ttf",
+            "/System/Library/Fonts/Monaco.ttf",
             "/Library/Fonts/Menlo.ttc",
             "/System/Library/Fonts/Menlo.ttc",
         };

--- a/src/AcDream.App/Rendering/FramePacingDuration.cs
+++ b/src/AcDream.App/Rendering/FramePacingDuration.cs
@@ -1,0 +1,35 @@
+namespace AcDream.App.Rendering;
+
+/// <summary>
+/// Frame-deadline arithmetic shared by the platform waiters. The math is
+/// the same everywhere; only the clock the deadline is handed to differs.
+/// </summary>
+internal static class FramePacingDuration
+{
+    private const long NanosecondsPerSecond = 1_000_000_000L;
+
+    internal static long ConvertTicksToNanoseconds(
+        long durationTicks,
+        long clockFrequency)
+    {
+        if (durationTicks <= 0)
+            throw new ArgumentOutOfRangeException(nameof(durationTicks));
+        if (clockFrequency <= 0)
+            throw new ArgumentOutOfRangeException(nameof(clockFrequency));
+
+        long wholeSeconds = Math.DivRem(
+            durationTicks,
+            clockFrequency,
+            out long remainder);
+        if (wholeSeconds >= long.MaxValue / NanosecondsPerSecond)
+            return long.MaxValue;
+
+        long wholeNanoseconds = wholeSeconds * NanosecondsPerSecond;
+        long fractionalNanoseconds = checked((long)Math.Ceiling(
+            remainder * (double)NanosecondsPerSecond / clockFrequency));
+        if (wholeNanoseconds > long.MaxValue - fractionalNanoseconds)
+            return long.MaxValue;
+
+        return Math.Max(1L, wholeNanoseconds + fractionalNanoseconds);
+    }
+}

--- a/src/AcDream.App/Rendering/FramePacingWaiterFactory.cs
+++ b/src/AcDream.App/Rendering/FramePacingWaiterFactory.cs
@@ -32,6 +32,8 @@ internal sealed class PlatformFramePacingWaiterFactory
                 WindowsHighResolutionFramePacingWaiter.Create(),
             GraphicalHostOperatingSystem.Linux =>
                 LinuxMonotonicFramePacingWaiter.Create(),
+            GraphicalHostOperatingSystem.MacOS =>
+                MacMonotonicFramePacingWaiter.Create(),
             _ => throw new ArgumentOutOfRangeException(
                 nameof(_operatingSystem)),
         };

--- a/src/AcDream.App/Rendering/Gpu/Vk/VulkanExtensionSelection.cs
+++ b/src/AcDream.App/Rendering/Gpu/Vk/VulkanExtensionSelection.cs
@@ -22,6 +22,21 @@ internal static class VulkanExtensionSelection
     /// <summary>Presenting to a surface. Required on the real device; absent in the headless probe.</summary>
     internal const string SwapchainExtension = "VK_KHR_swapchain";
 
+    /// <summary>
+    /// Lets the loader report non-conformant implementations. MoltenVK on
+    /// macOS is one, so without this the loader enumerates no devices at all.
+    /// Enabled whenever advertised; absent on conformant drivers.
+    /// </summary>
+    internal const string PortabilityEnumerationExtension =
+        "VK_KHR_portability_enumeration";
+
+    /// <summary>
+    /// The spec requires this be enabled whenever the physical device
+    /// advertises it, which MoltenVK always does.
+    /// </summary>
+    internal const string PortabilitySubsetExtension =
+        "VK_KHR_portability_subset";
+
     internal static VulkanExtensionPlan Resolve(
         IReadOnlyList<string> available,
         IReadOnlyList<string> required,
@@ -69,5 +84,15 @@ internal static class VulkanExtensionSelection
         [DebugUtilsExtension];
 
     internal static IReadOnlyList<string> OptionalDeviceExtensions { get; } =
-        [MemoryBudgetExtension, PresentWaitExtension];
+        [MemoryBudgetExtension, PresentWaitExtension, PortabilitySubsetExtension];
+
+    /// <summary>
+    /// Portability is not a debug nicety, so it stays on the optional list
+    /// even when the caller declined the rest of the optional extensions.
+    /// </summary>
+    internal static IReadOnlyList<string> ResolveOptionalInstanceExtensions(
+        bool enableOptionalExtensions) =>
+        enableOptionalExtensions
+            ? [.. OptionalInstanceExtensions, PortabilityEnumerationExtension]
+            : [PortabilityEnumerationExtension];
 }

--- a/src/AcDream.App/Rendering/Gpu/Vk/VulkanInterop.cs
+++ b/src/AcDream.App/Rendering/Gpu/Vk/VulkanInterop.cs
@@ -119,9 +119,8 @@ internal sealed unsafe class VulkanInstanceFactory
         VulkanExtensionPlan plan = VulkanExtensionSelection.Resolve(
             available,
             requiredExtensions,
-            enableOptionalExtensions
-                ? VulkanExtensionSelection.OptionalInstanceExtensions
-                : []);
+            VulkanExtensionSelection.ResolveOptionalInstanceExtensions(
+                enableOptionalExtensions));
         if (!plan.IsSatisfied)
         {
             throw new NotSupportedException(
@@ -148,9 +147,15 @@ internal sealed unsafe class VulkanInstanceFactory
                 EngineVersion = VulkanApiVersion.Make(0, 1, 0),
                 ApiVersion = apiVersion,
             };
+            bool portability = plan.Enabled.Contains(
+                VulkanExtensionSelection.PortabilityEnumerationExtension,
+                StringComparer.Ordinal);
             var create = new InstanceCreateInfo
             {
                 SType = StructureType.InstanceCreateInfo,
+                Flags = portability
+                    ? InstanceCreateFlags.EnumeratePortabilityBitKhr
+                    : InstanceCreateFlags.None,
                 PApplicationInfo = &application,
                 EnabledExtensionCount = (uint)plan.Enabled.Count,
                 PpEnabledExtensionNames = (byte**)extensionNames,

--- a/src/AcDream.App/Rendering/LinuxMonotonicFramePacingWaiter.cs
+++ b/src/AcDream.App/Rendering/LinuxMonotonicFramePacingWaiter.cs
@@ -42,9 +42,10 @@ internal sealed partial class LinuxMonotonicFramePacingWaiter
                 "Could not read the Linux monotonic clock.");
         }
 
-        long durationNanoseconds = ConvertTicksToNanoseconds(
-            durationTicks,
-            clockFrequency);
+        long durationNanoseconds =
+            FramePacingDuration.ConvertTicksToNanoseconds(
+                durationTicks,
+                clockFrequency);
         Timespec deadline = AddNanoseconds(now, durationNanoseconds);
         do
         {
@@ -62,31 +63,6 @@ internal sealed partial class LinuxMonotonicFramePacingWaiter
                 result,
                 "Waiting on the Linux monotonic frame deadline failed.");
         }
-    }
-
-    internal static long ConvertTicksToNanoseconds(
-        long durationTicks,
-        long clockFrequency)
-    {
-        if (durationTicks <= 0)
-            throw new ArgumentOutOfRangeException(nameof(durationTicks));
-        if (clockFrequency <= 0)
-            throw new ArgumentOutOfRangeException(nameof(clockFrequency));
-
-        long wholeSeconds = Math.DivRem(
-            durationTicks,
-            clockFrequency,
-            out long remainder);
-        if (wholeSeconds >= long.MaxValue / NanosecondsPerSecond)
-            return long.MaxValue;
-
-        long wholeNanoseconds = wholeSeconds * NanosecondsPerSecond;
-        long fractionalNanoseconds = checked((long)Math.Ceiling(
-            remainder * (double)NanosecondsPerSecond / clockFrequency));
-        if (wholeNanoseconds > long.MaxValue - fractionalNanoseconds)
-            return long.MaxValue;
-
-        return Math.Max(1L, wholeNanoseconds + fractionalNanoseconds);
     }
 
     private static Timespec AddNanoseconds(

--- a/src/AcDream.App/Rendering/MacMonotonicFramePacingWaiter.cs
+++ b/src/AcDream.App/Rendering/MacMonotonicFramePacingWaiter.cs
@@ -1,0 +1,125 @@
+using System.Runtime.InteropServices;
+
+namespace AcDream.App.Rendering;
+
+/// <summary>
+/// macOS has no <c>clock_nanosleep</c>, so the frame deadline is held with
+/// mach's absolute-time timer. Mach units are not nanoseconds: on Apple
+/// silicon the timebase is 125/3, so every duration is converted through
+/// <see cref="MachTimebase"/> before it becomes a deadline.
+/// </summary>
+internal sealed partial class MacMonotonicFramePacingWaiter
+    : IFramePacingWaiter,
+      IDisposable
+{
+    private const int KernSuccess = 0;
+    private const int KernAborted = 14;
+
+    private readonly uint _timebaseNumerator;
+    private readonly uint _timebaseDenominator;
+    private bool _disposed;
+
+    private MacMonotonicFramePacingWaiter(
+        uint timebaseNumerator,
+        uint timebaseDenominator)
+    {
+        _timebaseNumerator = timebaseNumerator;
+        _timebaseDenominator = timebaseDenominator;
+    }
+
+    internal static MacMonotonicFramePacingWaiter Create()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            throw new PlatformNotSupportedException(
+                "The monotonic mach frame waiter requires macOS.");
+        }
+
+        if (MachTimebaseInfo(out MachTimebase timebase) != KernSuccess
+            || timebase.Numerator == 0
+            || timebase.Denominator == 0)
+        {
+            throw new InvalidOperationException(
+                "Could not read the mach clock timebase.");
+        }
+
+        return new MacMonotonicFramePacingWaiter(
+            timebase.Numerator,
+            timebase.Denominator);
+    }
+
+    public void Wait(long durationTicks, long clockFrequency)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (durationTicks <= 0 || clockFrequency <= 0)
+            return;
+
+        long durationNanoseconds =
+            FramePacingDuration.ConvertTicksToNanoseconds(
+                durationTicks,
+                clockFrequency);
+        ulong deadline = AddMachUnits(
+            MachAbsoluteTime(),
+            ConvertNanosecondsToMachUnits(
+                durationNanoseconds,
+                _timebaseNumerator,
+                _timebaseDenominator));
+
+        int result;
+        do
+        {
+            result = MachWaitUntil(deadline);
+        }
+        while (result == KernAborted);
+
+        if (result != KernSuccess)
+        {
+            throw new InvalidOperationException(
+                "Waiting on the mach frame deadline failed with " +
+                $"kern_return_t {result}.");
+        }
+    }
+
+    internal static ulong ConvertNanosecondsToMachUnits(
+        long nanoseconds,
+        uint timebaseNumerator,
+        uint timebaseDenominator)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(timebaseNumerator);
+        ArgumentOutOfRangeException.ThrowIfZero(timebaseDenominator);
+        if (nanoseconds <= 0)
+            return 0UL;
+
+        UInt128 machUnits =
+            (UInt128)(ulong)nanoseconds
+            * timebaseDenominator
+            / timebaseNumerator;
+        if (machUnits > ulong.MaxValue)
+            return ulong.MaxValue;
+
+        // A positive duration never rounds down to "do not wait": the shared
+        // tick conversion makes the same guarantee one unit up the chain.
+        return Math.Max(1UL, (ulong)machUnits);
+    }
+
+    private static ulong AddMachUnits(ulong timestamp, ulong delta) =>
+        timestamp > ulong.MaxValue - delta
+            ? ulong.MaxValue
+            : timestamp + delta;
+
+    public void Dispose() => _disposed = true;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly record struct MachTimebase(
+        uint Numerator,
+        uint Denominator);
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "mach_timebase_info")]
+    private static partial int MachTimebaseInfo(out MachTimebase timebase);
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "mach_absolute_time")]
+    private static partial ulong MachAbsoluteTime();
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "mach_wait_until")]
+    private static partial int MachWaitUntil(ulong deadline);
+}

--- a/tests/AcDream.App.Tests/Platform/GraphicalHostPlatformServicesTests.cs
+++ b/tests/AcDream.App.Tests/Platform/GraphicalHostPlatformServicesTests.cs
@@ -51,6 +51,22 @@ public sealed class GraphicalHostPlatformServicesTests
             return;
         }
 
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.Equal(
+                GraphicalHostOperatingSystem.MacOS,
+                platform.OperatingSystem);
+            Assert.StartsWith(
+                "osx-",
+                platform.RuntimeIdentifier,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                platform.NativeDependencies,
+                dependency =>
+                    dependency.PublishedFileName == "libglfw.3.dylib");
+            return;
+        }
+
         throw new PlatformNotSupportedException();
     }
 }

--- a/tests/AcDream.App.Tests/Rendering/LinuxMonotonicFramePacingWaiterTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/LinuxMonotonicFramePacingWaiterTests.cs
@@ -17,7 +17,7 @@ public sealed class LinuxMonotonicFramePacingWaiterTests
     {
         Assert.Equal(
             expected,
-            LinuxMonotonicFramePacingWaiter
+            FramePacingDuration
                 .ConvertTicksToNanoseconds(ticks, frequency));
     }
 
@@ -40,6 +40,13 @@ public sealed class LinuxMonotonicFramePacingWaiterTests
         if (OperatingSystem.IsLinux())
         {
             Assert.IsType<LinuxMonotonicFramePacingWaiter>(waiter);
+            ((IDisposable)waiter).Dispose();
+            return;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.IsType<MacMonotonicFramePacingWaiter>(waiter);
             ((IDisposable)waiter).Dispose();
             return;
         }

--- a/tests/AcDream.App.Tests/Rendering/LinuxPlatformBoundaryTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/LinuxPlatformBoundaryTests.cs
@@ -79,6 +79,8 @@ public sealed class LinuxPlatformBoundaryTests
                     && relative is not
                         "Rendering/LinuxMonotonicFramePacingWaiter.cs"
                     && relative is not
+                        "Rendering/MacMonotonicFramePacingWaiter.cs"
+                    && relative is not
                         "Rendering/WindowsHighResolutionFramePacingWaiter.cs";
             })
             .Select(path => Path.GetRelativePath(app, path))

--- a/tests/AcDream.App.Tests/Rendering/MacMonotonicFramePacingWaiterTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/MacMonotonicFramePacingWaiterTests.cs
@@ -1,0 +1,63 @@
+using AcDream.App.Rendering;
+
+namespace AcDream.App.Tests.Rendering;
+
+public sealed class MacMonotonicFramePacingWaiterTests
+{
+    // Apple silicon reports a 125/3 timebase, so mach units are not
+    // nanoseconds; x86 Macs report 1/1, where they are.
+    [Theory]
+    [InlineData(1_000L, 125u, 3u, 24UL)]
+    [InlineData(125_000L, 125u, 3u, 3_000UL)]
+    [InlineData(1_000L, 1u, 1u, 1_000UL)]
+    [InlineData(41L, 125u, 3u, 1UL)]
+    public void NanosecondsConvertThroughTheReportedTimebase(
+        long nanoseconds,
+        uint numerator,
+        uint denominator,
+        ulong expected)
+    {
+        Assert.Equal(
+            expected,
+            MacMonotonicFramePacingWaiter.ConvertNanosecondsToMachUnits(
+                nanoseconds,
+                numerator,
+                denominator));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void NonPositiveDurationsWaitForNothing(long nanoseconds)
+    {
+        Assert.Equal(
+            0UL,
+            MacMonotonicFramePacingWaiter.ConvertNanosecondsToMachUnits(
+                nanoseconds,
+                125u,
+                3u));
+    }
+
+    [Fact]
+    public void AnOverlongDurationSaturatesInsteadOfWrapping()
+    {
+        Assert.Equal(
+            ulong.MaxValue,
+            MacMonotonicFramePacingWaiter.ConvertNanosecondsToMachUnits(
+                long.MaxValue,
+                1u,
+                1_000u));
+    }
+
+    [Theory]
+    [InlineData(0u, 3u)]
+    [InlineData(125u, 0u)]
+    public void AnUnusableTimebaseIsRejected(uint numerator, uint denominator)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MacMonotonicFramePacingWaiter.ConvertNanosecondsToMachUnits(
+                1_000L,
+                numerator,
+                denominator));
+    }
+}


### PR DESCRIPTION
Adds `osx-arm64` as a supported target for the graphical client. Built and played against a local ACEmulator server on an M5 Pro MacBook.

## What was missing

Platform branching was two-way, so macOS fell into the Linux arm and then hit `PlatformNotSupportedException`. Four real gaps sat behind that:

- **RID and native closure** — no `osx` OS string, and `libglfw.3.dylib` / `libopenal.dylib` were never named. Both already ship in the Silk.NET packages for `osx-arm64`, so nothing new is vendored.

- **Frame pacing** — macOS has no `clock_nanosleep`. `MacMonotonicFramePacingWaiter` holds the deadline with `mach_wait_until` instead. Apple silicon reports a 125/3 timebase, so durations convert through `mach_timebase_info` rather than being treated as nanoseconds. The tick arithmetic both waiters shared moved to `FramePacingDuration`, which is why `LinuxMonotonicFramePacingWaiter` shrinks here.

- **Vulkan** — MoltenVK is a non-conformant implementation, so the loader enumerates no device at all unless the instance opts in. Enables `VK_KHR_portability_enumeration` with the `EnumeratePortabilityBitKhr` flag, and `VK_KHR_portability_subset` on the device, which the spec requires whenever a device advertises it.

- **Font** — the candidate list already carried macOS paths, but `Menlo.ttc` is a collection whose first font does not start at offset 0, so `stbtt_InitFont` rejects it. This prefers the plain `.ttf` faces and keeps the collections last.

## Verification

Portable gate is green on macOS apart from the launcher lanes, which this PR does not touch. End to end on an M5 Pro:

- 570 MB package baked from End-of-Retail dats, 2,237,865 keys, 0 failures
- server-side interrogation returned `portal 2072 | cell 982 | English 994 | no update required`
- renderer up on `Apple M5 Pro, Vulkan 1.3.357` through MoltenVK, 4x MSAA
- OpenAL engine ready, 16 voices, 3D positional
- full retail UI from the dats; fullscreen works

Prerequisites are documented in `docs/building-and-running.md`: `brew install molten-vk vulkan-loader`, plus `VK_ICD_FILENAMES` pointing at `MoltenVK_icd.json`.

## Not included

- **The launcher** is unchanged and remains Windows and Linux only. It is a separate topic and a much larger diff.
- **No macOS CI lane.** `macos-latest` runners are arm64 and would work, but it needs a `Lane=MacOS` trait and edits to all five copies of the gate filter plus `GitHubWorkflowFilterContractTests`. That felt like your call rather than something to bundle in here.
- **No `osx-arm64` lock files.** Restoring for the new RID generated some locally; they are left out since the publish matrix is win-x64 and linux-x64 only.