### PR TITLE
Add salvaging and fix rendering and interface issues

### DIFF
--- a/src/AcDream.App/Composition/FrameRootComposition.cs
+++ b/src/AcDream.App/Composition/FrameRootComposition.cs
@@ -324,7 +324,10 @@ internal sealed class FrameRootCompositionPhase
             content.ParticleSink,
             d.EffectPoses,
             live.EntityEffects,
-            d.Log);
+            d.Log,
+            content.Audio is { } audio
+                ? audio.Engine.StopAllForOwner
+                : null);
         IWorldSceneFramePhase? worldSceneRenderer = null;
         CurrentRenderSceneOracle? currentRenderSceneOracle = null;
         RenderSceneShadowComparisonController? renderSceneShadowComparison = null;
@@ -352,10 +355,26 @@ internal sealed class FrameRootCompositionPhase
                     persistentDaylight: () =>
                         d.Runtime.CharacterOwner.Options.GetOptionBit(
                             CharacterOptionId.PersistentAtDay));
+            var worldFrameCamera = new RuntimeWorldFrameCameraSource(
+                host.CameraController,
+                session.LocalTeleport.ApplyViewPlane);
+            var worldFrameRoots = new RuntimeWorldFrameRootSource(
+                d.PhysicsEngine,
+                d.CellVisibility,
+                d.PlayerMode,
+                d.ChaseCameraInput,
+                d.PlayerController,
+                d.WorldOrigin);
+            var skyPesActivationGate = new RuntimeSkyPesActivationGate(
+                skyPesFrame,
+                worldFrameCamera,
+                worldFrameRoots);
+            bindings.Adopt(
+                "sky presentation effects activation",
+                session.LiveObjectFrame.BindSkyPesActivationGateOwned(
+                    skyPesActivationGate));
             var worldRenderFrameBuilder = new WorldRenderFrameBuilder(
-                new RuntimeWorldFrameCameraSource(
-                    host.CameraController,
-                    session.LocalTeleport),
+                worldFrameCamera,
                 new RuntimeWorldFrameVisibilityPreparation(
                     live.SelectionScene,
                     d.ParticleVisibility,
@@ -367,13 +386,7 @@ internal sealed class FrameRootCompositionPhase
                     content.Audio?.Engine,
                     host.CameraController,
                     d.DisplayFramePacing),
-                new RuntimeWorldFrameRootSource(
-                    d.PhysicsEngine,
-                    d.CellVisibility,
-                    d.PlayerMode,
-                    d.ChaseCameraInput,
-                    d.PlayerController,
-                    d.WorldOrigin),
+                worldFrameRoots,
                 worldFrameEnvironment,
                 new RuntimeWorldFrameAnimatedEntitySource(
                     d.Animations,

--- a/src/AcDream.App/Rendering/CompositeTextureArrayCache.cs
+++ b/src/AcDream.App/Rendering/CompositeTextureArrayCache.cs
@@ -8,15 +8,21 @@ internal readonly struct BindlessTextureLocation : IEquatable<BindlessTextureLoc
 {
     private readonly uint _slotPlusOne;
 
-    public BindlessTextureLocation(GpuTextureSlot slot, uint layer)
+    public BindlessTextureLocation(GpuTextureSlot slot, uint layer, GpuTextureSlot repeatSlot = default)
     {
         _slotPlusOne = slot.IsAssigned ? slot.Index + 1 : 0;
         Layer = layer;
+        RepeatSlot = repeatSlot;
     }
 
     public static BindlessTextureLocation Unresolved => default;
 
     public uint Layer { get; }
+
+    public GpuTextureSlot RepeatSlot { get; }
+
+    public GpuTextureSlot ResolveSlot(bool wrapping) =>
+        wrapping && RepeatSlot.IsAssigned ? RepeatSlot : Slot;
 
     public bool IsResolved => _slotPlusOne != 0;
 
@@ -24,12 +30,12 @@ internal readonly struct BindlessTextureLocation : IEquatable<BindlessTextureLoc
         _slotPlusOne == 0 ? GpuTextureSlot.Unassigned : new GpuTextureSlot(_slotPlusOne - 1);
 
     public bool Equals(BindlessTextureLocation other) =>
-        _slotPlusOne == other._slotPlusOne && Layer == other.Layer;
+        _slotPlusOne == other._slotPlusOne && Layer == other.Layer && RepeatSlot == other.RepeatSlot;
 
     public override bool Equals(object? obj) =>
         obj is BindlessTextureLocation other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(_slotPlusOne, Layer);
+    public override int GetHashCode() => HashCode.Combine(_slotPlusOne, Layer, RepeatSlot);
 
     public static bool operator ==(BindlessTextureLocation left, BindlessTextureLocation right) =>
         left.Equals(right);
@@ -107,6 +113,7 @@ internal sealed class CompositeTextureArrayResource
     public Gpu.IGpuTexture? Image { get; init; }
 
     public required GpuTextureSlot Slot { get; init; }
+    public GpuTextureSlot RepeatSlot { get; init; }
     public required int Width { get; init; }
     public required int Height { get; init; }
     public required int Capacity { get; init; }
@@ -126,10 +133,15 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
 {
     private readonly Gpu.IGpuDevice _device;
     private readonly Gpu.IGpuSampler _sampler;
+    private readonly Gpu.IGpuSampler _repeatSampler;
 
     internal RhiCompositeTextureArrayBackend(Gpu.IGpuDevice device)
     {
         _device = device ?? throw new ArgumentNullException(nameof(device));
+        _repeatSampler = device.CreateSampler(Gpu.GpuSamplerDescription.WorldRepeat with
+        {
+            MipFilter = Gpu.GpuMipFilter.None,
+        });
         _sampler = device.CreateSampler(Gpu.GpuSamplerDescription.WorldClamp with
         {
             MipFilter = Gpu.GpuMipFilter.None,
@@ -143,6 +155,8 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
     public CompositeTextureArrayResource Create(int width, int height, int capacity)
     {
         Gpu.IGpuTexture? image = null;
+        GpuTextureSlot slot = default;
+        GpuTextureSlot repeatSlot = default;
         try
         {
             image = _device.CreateTexture(new Gpu.GpuTextureDescription(
@@ -153,13 +167,15 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
                 height,
                 capacity,
                 MipLevelCount: 1));
-            Gpu.GpuTextureSlot slot = _device.RegisterTexture(image, _sampler);
+            slot = _device.RegisterTexture(image, _sampler);
+            repeatSlot = _device.RegisterTexture(image, _repeatSampler);
             return new CompositeTextureArrayResource
             {
                 Name = 0,
                 Handle = 0,
                 Image = image,
                 Slot = slot,
+                RepeatSlot = repeatSlot,
                 Width = width,
                 Height = height,
                 Capacity = capacity,
@@ -168,6 +184,10 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
         }
         catch
         {
+            if (repeatSlot.IsAssigned)
+                _device.ReleaseTextureSlot(repeatSlot);
+            if (slot.IsAssigned)
+                _device.ReleaseTextureSlot(slot);
             image?.Dispose();
             throw;
         }
@@ -187,6 +207,8 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
         ArgumentNullException.ThrowIfNull(resource);
         if (resource.Slot.IsAssigned)
             _device.ReleaseTextureSlot(resource.Slot);
+        if (resource.RepeatSlot.IsAssigned)
+            _device.ReleaseTextureSlot(resource.RepeatSlot);
     }
 
     public void Delete(CompositeTextureArrayResource resource) => RequireImage(resource).Dispose();
@@ -426,7 +448,8 @@ internal sealed class CompositeTextureArrayCache : IDisposable
         entry.Atlas.LastUseSequence = ++_useSequence;
         location = new BindlessTextureLocation(
             entry.Atlas.Resource.Slot,
-            checked((uint)entry.Layer));
+            checked((uint)entry.Layer),
+            entry.Atlas.Resource.RepeatSlot);
         return true;
     }
 
@@ -488,7 +511,7 @@ internal sealed class CompositeTextureArrayCache : IDisposable
         _owners.Acquire(ownerLocalId, key);
         _frameUploadCount++;
         _frameUploadBytes = checked(_frameUploadBytes + bytes);
-        location = new BindlessTextureLocation(atlas.Resource.Slot, checked((uint)layer));
+        location = new BindlessTextureLocation(atlas.Resource.Slot, checked((uint)layer), atlas.Resource.RepeatSlot);
         return true;
     }
 

--- a/src/AcDream.App/Rendering/CompositeTextureArrayCache.cs
+++ b/src/AcDream.App/Rendering/CompositeTextureArrayCache.cs
@@ -7,22 +7,29 @@ namespace AcDream.App.Rendering;
 internal readonly struct BindlessTextureLocation : IEquatable<BindlessTextureLocation>
 {
     private readonly uint _slotPlusOne;
+    private readonly uint _repeatSlotPlusOne;
 
-    public BindlessTextureLocation(GpuTextureSlot slot, uint layer, GpuTextureSlot repeatSlot = default)
+    public BindlessTextureLocation(GpuTextureSlot slot, uint layer)
+        : this(slot, layer, GpuTextureSlot.Unassigned)
+    {
+    }
+
+    public BindlessTextureLocation(GpuTextureSlot slot, uint layer, GpuTextureSlot repeatSlot)
     {
         _slotPlusOne = slot.IsAssigned ? slot.Index + 1 : 0;
         Layer = layer;
-        RepeatSlot = repeatSlot;
+        _repeatSlotPlusOne = repeatSlot.IsAssigned ? repeatSlot.Index + 1 : 0;
     }
 
     public static BindlessTextureLocation Unresolved => default;
 
     public uint Layer { get; }
 
-    public GpuTextureSlot RepeatSlot { get; }
+    public GpuTextureSlot RepeatSlot =>
+        _repeatSlotPlusOne == 0 ? GpuTextureSlot.Unassigned : new GpuTextureSlot(_repeatSlotPlusOne - 1);
 
     public GpuTextureSlot ResolveSlot(bool wrapping) =>
-        wrapping && RepeatSlot.IsAssigned ? RepeatSlot : Slot;
+        IsResolved && wrapping && RepeatSlot.IsAssigned ? RepeatSlot : Slot;
 
     public bool IsResolved => _slotPlusOne != 0;
 
@@ -113,7 +120,7 @@ internal sealed class CompositeTextureArrayResource
     public Gpu.IGpuTexture? Image { get; init; }
 
     public required GpuTextureSlot Slot { get; init; }
-    public GpuTextureSlot RepeatSlot { get; init; }
+    public GpuTextureSlot RepeatSlot { get; init; } = GpuTextureSlot.Unassigned;
     public required int Width { get; init; }
     public required int Height { get; init; }
     public required int Capacity { get; init; }
@@ -155,8 +162,8 @@ internal sealed class RhiCompositeTextureArrayBackend : ICompositeTextureArrayBa
     public CompositeTextureArrayResource Create(int width, int height, int capacity)
     {
         Gpu.IGpuTexture? image = null;
-        GpuTextureSlot slot = default;
-        GpuTextureSlot repeatSlot = default;
+        GpuTextureSlot slot = GpuTextureSlot.Unassigned;
+        GpuTextureSlot repeatSlot = GpuTextureSlot.Unassigned;
         try
         {
             image = _device.CreateTexture(new Gpu.GpuTextureDescription(

--- a/src/AcDream.App/Rendering/RetailPViewRenderer.cs
+++ b/src/AcDream.App/Rendering/RetailPViewRenderer.cs
@@ -101,7 +101,8 @@ internal sealed class RetailPViewRenderer
                     viewportWidth,
                     viewportHeight,
                     ctx.ViewerCellId,
-                    weatherGateOpen);
+                    weatherGateOpen,
+                    ctx.BuildingDegradesDisabled);
             }
             else
             {
@@ -112,7 +113,8 @@ internal sealed class RetailPViewRenderer
                     viewportWidth,
                     viewportHeight,
                     ctx.ViewerCellId,
-                    weatherGateOpen);
+                    weatherGateOpen,
+                    ctx.BuildingDegradesDisabled);
             }
             Walk.WalkProductionFrameContext walkContext = _walkFrameContextScratch;
             _walkLandscape!.SetViewer(ctx.ViewerCellId, ctx.ViewerEyePos);
@@ -427,6 +429,7 @@ public sealed class RetailPViewFrameInput
 
     public bool RenderSky { get; private set; }
     public bool RenderWeather { get; private set; }
+    public bool BuildingDegradesDisabled { get; private set; }
     public float DayFraction { get; private set; }
     public DayGroupData? ActiveDayGroup { get; private set; }
     public SkyKeyframe SkyKeyframe { get; private set; }
@@ -464,7 +467,8 @@ public sealed class RetailPViewFrameInput
         uint playerCellId,
         Vector3 playerViewPosition,
         Matrix4x4 cameraView,
-        CameraCellResolution cameraCellResolution)
+        CameraCellResolution cameraCellResolution,
+        bool buildingDegradesDisabled = false)
     {
         RootCell = rootCell;
         NearbyBuildingCells = nearbyBuildingCells;
@@ -491,6 +495,7 @@ public sealed class RetailPViewFrameInput
         PlayerViewPosition = playerViewPosition;
         CameraView = cameraView;
         CameraCellResolution = cameraCellResolution;
+        BuildingDegradesDisabled = buildingDegradesDisabled;
         return this;
     }
 }

--- a/src/AcDream.App/Rendering/SkyPesFrameController.cs
+++ b/src/AcDream.App/Rendering/SkyPesFrameController.cs
@@ -19,6 +19,7 @@ internal sealed class SkyPesFrameController
     private readonly ParticleHookSink _particles;
     private readonly EntityEffectPoseRegistry _poses;
     private readonly EntityEffectController? _effects;
+    private readonly Action<uint>? _stopAudio;
     private readonly HashSet<SkyPesKey> _active = [];
     private readonly HashSet<SkyPesKey> _missing = [];
     private readonly HashSet<uint> _reportedScriptMismatches = [];
@@ -31,20 +32,29 @@ internal sealed class SkyPesFrameController
         ParticleHookSink particles,
         EntityEffectPoseRegistry poses,
         EntityEffectController? effects,
-        Action<string>? diagnostic = null)
+        Action<string>? diagnostic = null,
+        Action<uint>? stopAudio = null)
     {
         _scripts = scripts ?? throw new ArgumentNullException(nameof(scripts));
         _particles = particles ?? throw new ArgumentNullException(nameof(particles));
         _poses = poses ?? throw new ArgumentNullException(nameof(poses));
         _effects = effects;
         _diagnostic = diagnostic;
+        _stopAudio = stopAudio;
     }
 
     public void Update(
         float dayFraction,
         DayGroupData? dayGroup,
-        Vector3 cameraWorldPosition)
+        Vector3 cameraWorldPosition,
+        bool skyActive = true)
     {
+        if (!skyActive)
+        {
+            SetActive(false);
+            return;
+        }
+
         _seenScratch.Clear();
         if (dayGroup is not null)
         {
@@ -113,6 +123,16 @@ internal sealed class SkyPesFrameController
         }
     }
 
+    public void SetActive(bool skyActive)
+    {
+        if (skyActive)
+            return;
+
+        _seenScratch.Clear();
+        StopUnseen(_active, stopScripts: true);
+        StopUnseen(_missing, stopScripts: false);
+    }
+
     private void StopUnseen(HashSet<SkyPesKey> set, bool stopScripts)
     {
         _stopScratch.Clear();
@@ -131,6 +151,7 @@ internal sealed class SkyPesFrameController
                 _effects?.UnregisterSyntheticOwner(ownerId);
                 _particles.StopAllForEntity(ownerId, fadeOut: true);
                 _poses.Remove(ownerId);
+                _stopAudio?.Invoke(ownerId);
             }
 
             set.Remove(key);

--- a/src/AcDream.App/Rendering/Walk/RetailFrameWalk.cs
+++ b/src/AcDream.App/Rendering/Walk/RetailFrameWalk.cs
@@ -14,6 +14,7 @@ public interface IRetailFrameWalkContext : IWalkBuildingFrameContext
     uint ViewerCellId => 0u;
 
     bool WeatherGateOpen => false;
+    bool BuildingDegradesDisabled => false;
 }
 
 public sealed class RetailFrameWalk
@@ -125,6 +126,11 @@ public sealed class RetailFrameWalk
                     DrawBuilding(building, activeViews, ctx, sink);
                 if (block.SideCellCount == 8 || block.Ring <= ObjectRingLimit)
                 {
+                    if ((uint)cellIndex < (uint)block.CoarseCellBuildings.Length)
+                    {
+                        foreach (WalkBuilding coarseBuilding in block.CoarseCellBuildings[cellIndex])
+                            DrawBuilding(coarseBuilding, activeViews, ctx, sink);
+                    }
                     sink.OnLandscapeCellTurn(
                         block.LandblockId,
                         block.SideCellCount,
@@ -150,7 +156,8 @@ public sealed class RetailFrameWalk
         WalkBuildingSelection selection = building.Select(
             ctx.ViewerDistanceTo(building),
             _degradation?.DegradeDistance ?? _fixedDegradeDistance ?? 50f,
-            _degradation?.ActiveMultiplier ?? _fixedDegradeMultiplier ?? 0f);
+            _degradation?.ActiveMultiplier ?? _fixedDegradeMultiplier ?? 0f,
+            degradesDisabled: ctx.BuildingDegradesDisabled);
         if (selection.GfxObjId == 0)
             return;
 

--- a/src/AcDream.App/Rendering/Walk/WalkLandscape.cs
+++ b/src/AcDream.App/Rendering/Walk/WalkLandscape.cs
@@ -11,6 +11,7 @@ public sealed class WalkLandBlock
     public int Ring;
 
     public WalkBuilding?[] CellBuildings = [];
+    public WalkBuilding[][] CoarseCellBuildings = [];
 
     // ---- per-frame visibility (draw_check_blocks / landcell_check) ----
     public WalkBoundingType InView;

--- a/src/AcDream.App/Rendering/Walk/WalkLandscapeAssembler.cs
+++ b/src/AcDream.App/Rendering/Walk/WalkLandscapeAssembler.cs
@@ -152,6 +152,23 @@ public sealed class WalkLandscapeAssembler
                     block.CellBuildings[cellIndex] = entry.Building;
             }
         }
+        else if (sideCellCount > 1 && data.Buildings.Count > 0)
+        {
+            // A coarse terrain cell can cover several building anchors.
+            int span = 8 / sideCellCount;
+            var buckets = new List<WalkBuilding>?[sideCellCount * sideCellCount];
+            foreach (WalkBuildingFactory.Entry entry in data.Buildings)
+            {
+                int anchor = (int)(entry.Building.PositionCellId & 0xFFFFu) - 1;
+                if ((uint)anchor >= 64u)
+                    continue;
+                int cell = (anchor / 8 / span) * sideCellCount + anchor % 8 / span;
+                (buckets[cell] ??= []).Add(entry.Building);
+            }
+            block.CoarseCellBuildings = new WalkBuilding[buckets.Length][];
+            for (int i = 0; i < buckets.Length; i++)
+                block.CoarseCellBuildings[i] = buckets[i]?.ToArray() ?? [];
+        }
         return block;
     }
 

--- a/src/AcDream.App/Rendering/Walk/WalkProductionFrameContext.cs
+++ b/src/AcDream.App/Rendering/Walk/WalkProductionFrameContext.cs
@@ -61,7 +61,8 @@ public sealed class WalkProductionFrameContext : IWalkFrameContext, IRetailFrame
         float viewportWidth,
         float viewportHeight,
         uint viewerCellId = 0u,
-        bool weatherGateOpen = false)
+        bool weatherGateOpen = false,
+        bool buildingDegradesDisabled = false)
     {
         _cells = cells ?? throw new ArgumentNullException(nameof(cells));
         _buildings = buildings ?? throw new ArgumentNullException(nameof(buildings));
@@ -69,7 +70,7 @@ public sealed class WalkProductionFrameContext : IWalkFrameContext, IRetailFrame
             viewProjection, viewportWidth, viewportHeight);
         Reset(
             worldViewpoint, forward, viewProjection, viewportWidth, viewportHeight,
-            viewerCellId, weatherGateOpen);
+            viewerCellId, weatherGateOpen, buildingDegradesDisabled);
     }
 
     internal void Reset(
@@ -79,7 +80,8 @@ public sealed class WalkProductionFrameContext : IWalkFrameContext, IRetailFrame
         float viewportWidth,
         float viewportHeight,
         uint viewerCellId = 0u,
-        bool weatherGateOpen = false)
+        bool weatherGateOpen = false,
+        bool buildingDegradesDisabled = false)
     {
         _rays.Reset(viewProjection, viewportWidth, viewportHeight);
         WorldViewpoint = worldViewpoint;
@@ -88,6 +90,7 @@ public sealed class WalkProductionFrameContext : IWalkFrameContext, IRetailFrame
         ViewportHeight = viewportHeight;
         ViewerCellId = viewerCellId;
         WeatherGateOpen = weatherGateOpen;
+        BuildingDegradesDisabled = buildingDegradesDisabled;
         _activeViewVertCount = 0;
         CyPlane = new WalkPlane(forward, -Vector3.Dot(worldViewpoint, forward) - ZNear);
     }
@@ -97,6 +100,7 @@ public sealed class WalkProductionFrameContext : IWalkFrameContext, IRetailFrame
     public float ViewportHeight { get; private set; }
     public uint ViewerCellId { get; private set; }
     public bool WeatherGateOpen { get; private set; }
+    public bool BuildingDegradesDisabled { get; private set; }
     public WalkPlane CyPlane { get; private set; }
     public IWalkRayCaster Rays => _rays;
     public IWalkFrameContext CellContext => this;

--- a/src/AcDream.App/Rendering/Wb/WbDrawDispatcher.cs
+++ b/src/AcDream.App/Rendering/Wb/WbDrawDispatcher.cs
@@ -2279,7 +2279,7 @@ public sealed partial class WbDrawDispatcher : IDisposable
                         paletteOverride!,
                         paletteIdentity);
                 compositePending = !texture.IsResolved;
-                return new ResolvedTexture(texture.Slot, texture.Layer);
+                return new ResolvedTexture(texture.ResolveSlot(batch.HasWrappingUVs), texture.Layer);
             }
 
             case WbTextureResolutionKind.OriginalTextureOverride:
@@ -2290,7 +2290,7 @@ public sealed partial class WbDrawDispatcher : IDisposable
                         surfaceId,
                         overrideOrigTex);
                 compositePending = !texture.IsResolved;
-                return new ResolvedTexture(texture.Slot, texture.Layer);
+                return new ResolvedTexture(texture.ResolveSlot(batch.HasWrappingUVs), texture.Layer);
             }
 
             case WbTextureResolutionKind.SharedAtlas:

--- a/src/AcDream.App/Rendering/WorldRenderFrameBuilder.cs
+++ b/src/AcDream.App/Rendering/WorldRenderFrameBuilder.cs
@@ -22,7 +22,24 @@ internal readonly record struct WorldCameraFrame(
     Matrix4x4 ViewProjection,
     FrustumPlanes Frustum,
     Matrix4x4 InverseView,
-    Vector3 Position);
+    Vector3 Position)
+{
+    public bool IsOverheadView { get; init; }
+}
+
+internal static class WorldCameraViewPolicy
+{
+    internal static bool IsOverheadView(ICamera activeCamera) =>
+        activeCamera is RetailChaseCamera { IsMapMode: true }
+            or ChaseCamera { IsMapMode: true };
+
+    internal static AtmosphereSnapshot Apply(
+        in AtmosphereSnapshot atmosphere,
+        bool distanceFogDisabled) =>
+        distanceFogDisabled
+            ? atmosphere with { FogMode = FogMode.Off }
+            : atmosphere;
+}
 
 internal readonly record struct WorldRootFrame(
     LoadedCell? PlayerRoot,
@@ -41,6 +58,8 @@ internal readonly record struct WorldRootFrame(
     bool PlayerIndoorGate)
 {
     public bool RenderSky => ViewerRoot is null || RootSeenOutside;
+
+    public bool SkyEffectsActive => RenderSky && !PlayerInsideCell;
 
     public bool CameraInsideEnclosedCell => CameraInsideCell && !RootSeenOutside;
 
@@ -151,6 +170,36 @@ internal interface IWorldFrameEnvironmentPreparation
 
 }
 
+internal interface ISkyPesActivationGate
+{
+    void Tick();
+}
+
+internal sealed class RuntimeSkyPesActivationGate
+    : ISkyPesActivationGate
+{
+    private readonly SkyPesFrameController _skyPes;
+    private readonly IWorldFrameCameraSource _camera;
+    private readonly IWorldFrameRootSource _roots;
+
+    public RuntimeSkyPesActivationGate(
+        SkyPesFrameController skyPes,
+        IWorldFrameCameraSource camera,
+        IWorldFrameRootSource roots)
+    {
+        _skyPes = skyPes ?? throw new ArgumentNullException(nameof(skyPes));
+        _camera = camera ?? throw new ArgumentNullException(nameof(camera));
+        _roots = roots ?? throw new ArgumentNullException(nameof(roots));
+    }
+
+    public void Tick()
+    {
+        WorldCameraFrame camera = _camera.Resolve();
+        WorldRootFrame roots = _roots.Resolve(in camera);
+        _skyPes.SetActive(roots.SkyEffectsActive);
+    }
+}
+
 internal interface IWorldFrameAnimatedEntitySource
 {
     HashSet<uint> Capture();
@@ -229,19 +278,22 @@ internal sealed class WorldRenderFrameBuilder : IWorldRenderFrameBuilder
 internal sealed class RuntimeWorldFrameCameraSource : IWorldFrameCameraSource
 {
     private readonly CameraController _cameras;
-    private readonly LocalPlayerTeleportController _teleport;
+    private readonly Func<ICamera, ICamera> _applyViewPlane;
 
     public RuntimeWorldFrameCameraSource(
         CameraController cameras,
-        LocalPlayerTeleportController teleport)
+        Func<ICamera, ICamera> applyViewPlane)
     {
         _cameras = cameras ?? throw new ArgumentNullException(nameof(cameras));
-        _teleport = teleport ?? throw new ArgumentNullException(nameof(teleport));
+        _applyViewPlane = applyViewPlane
+            ?? throw new ArgumentNullException(nameof(applyViewPlane));
     }
 
     public WorldCameraFrame Resolve()
     {
-        ICamera camera = _teleport.ApplyViewPlane(_cameras.Active);
+        ICamera activeCamera = _cameras.Active;
+        bool overheadView = WorldCameraViewPolicy.IsOverheadView(activeCamera);
+        ICamera camera = _applyViewPlane(activeCamera);
         Matrix4x4 projection = camera.Projection;
         Matrix4x4 viewProjection = camera.View * projection;
         FrustumPlanes frustum = FrustumPlanes.FromViewProjection(viewProjection);
@@ -253,7 +305,10 @@ internal sealed class RuntimeWorldFrameCameraSource : IWorldFrameCameraSource
             viewProjection,
             frustum,
             inverseView,
-            position);
+            position)
+        {
+            IsOverheadView = overheadView,
+        };
     }
 }
 
@@ -500,7 +555,8 @@ internal sealed class RuntimeWorldFrameEnvironmentPreparation
         _skyPes?.Update(
             (float)_worldTime.DayFraction,
             activeDayGroup,
-            camera.Position);
+            camera.Position,
+            roots.SkyEffectsActive);
 
         SkyKeyframe landscapeLighting = _persistentDaylight()
             ? _worldTime.SkyAtDayFraction(0.5f)
@@ -512,7 +568,9 @@ internal sealed class RuntimeWorldFrameEnvironmentPreparation
         _dispatcher?.SetSceneLights(_lighting.PointSnapshot);
         _environmentCells?.SetPointSnapshot(_lighting.PointSnapshot);
 
-        AtmosphereSnapshot atmosphere = foundation.Atmosphere;
+        AtmosphereSnapshot atmosphere = WorldCameraViewPolicy.Apply(
+            foundation.Atmosphere,
+            camera.IsOverheadView);
         SceneLightingUbo ubo = SceneLightingUbo.Build(
             _lighting,
             in atmosphere,

--- a/src/AcDream.App/Rendering/WorldSceneRenderer.cs
+++ b/src/AcDream.App/Rendering/WorldSceneRenderer.cs
@@ -210,7 +210,8 @@ internal sealed class WorldSceneRenderer : IPreparedWorldSceneFramePhase
                         roots.PlayerCellId,
                         roots.PlayerViewPosition,
                         camera.Camera.View,
-                        _diagnostics.CameraCellResolution));
+                        _diagnostics.CameraCellResolution,
+                        buildingDegradesDisabled: camera.IsOverheadView));
 
                 _particleVisibility.MarkVisibleLandscapeCells(
                     pviewResult.VisibleLandscapeCells);

--- a/src/AcDream.App/UI/ItemInteractionController.cs
+++ b/src/AcDream.App/UI/ItemInteractionController.cs
@@ -528,6 +528,9 @@ public sealed class ItemInteractionController : IDisposable
     public bool TrySalvageItemsForAutomation(
         uint toolId,
         IReadOnlyList<uint> itemIds)
+        => TrySalvageItems(toolId, itemIds);
+
+    public bool TrySalvageItems(uint toolId, IReadOnlyList<uint> itemIds)
     {
         if (_sendSalvage is null
             || toolId == 0u
@@ -549,9 +552,7 @@ public sealed class ItemInteractionController : IDisposable
                 || !distinct.Add(itemId)
                 || !IsOwnedByPlayer(itemId)
                 || _objects.Get(itemId) is not { } item
-                || item.MaterialType is null or 0u
-                || item.Structure >= 100
-                || ((item.PublicWeenieBitfield ?? 0u) & 0xFF000000u) != 0u)
+                || !SalvageItemPolicy.IsSuitable(item))
             {
                 return false;
             }

--- a/src/AcDream.App/UI/Layout/AppraisalUiController.cs
+++ b/src/AcDream.App/UI/Layout/AppraisalUiController.cs
@@ -6,6 +6,7 @@ using AcDream.Core.Items;
 using AcDream.Core.Net.Messages;
 using AcDream.Core.Selection;
 using AcDream.Core.Spells;
+using AcDream.UI.Abstractions.Input;
 
 namespace AcDream.App.UI.Layout;
 
@@ -997,6 +998,15 @@ public sealed class AppraisalUiController : IRetainedPanelController
     }
 
     public void OnHidden() => _windowVisible = false;
+
+    public bool HandleInputAction(InputAction action)
+    {
+        if (_disposed || !_windowVisible || action != InputAction.SelectionExamine)
+            return false;
+
+        _closeWindow();
+        return true;
+    }
 
     private void HandleSelectionChanged(SelectionTransition transition)
     {

--- a/src/AcDream.App/UI/Layout/InventoryController.cs
+++ b/src/AcDream.App/UI/Layout/InventoryController.cs
@@ -489,6 +489,7 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
             TooltipTextResolve = g => _objects.Get(g)?.GetTooltipDisplayName(),
         };
         cell.SetItem(guid, tex, dragIconTexture: dragTex);
+        SetStructureBar(cell, item);
         cell.SetWaitingState(waiting);
         cell.SlotIndex = list.GetNumUIItems();                 // index it will occupy (== its slot in a packed list)
         ConfigureDropFeedback(list, cell);
@@ -546,6 +547,11 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
         if (cap <= 0) { cell.CapacityFill = -1f; return; }
         int n = CountLooseContents(containerGuid);
         cell.CapacityFill = Math.Clamp(n / (float)cap, 0f, 1f);
+    }
+
+    private static void SetStructureBar(UiItemSlot cell, ClientObject? item)
+    {
+        cell.SetStructure(item?.Structure ?? 0, item?.MaxStructure ?? 0);
     }
 
     public void OnDragLift(UiItemList sourceList, UiItemSlot sourceCell, ItemDragPayload payload)

--- a/src/AcDream.App/UI/Layout/RetailPanelUiController.cs
+++ b/src/AcDream.App/UI/Layout/RetailPanelUiController.cs
@@ -17,6 +17,7 @@ public sealed class RetailPanelUiController : IDisposable
     private bool _applying;
     private bool _synchronizingGeometry;
     private PanelGeometry? _mainPanelGeometry;
+    private ElementInfo? _mainPanelFrame;
     private bool _disposed;
 
     public RetailPanelUiController(
@@ -31,6 +32,14 @@ public sealed class RetailPanelUiController : IDisposable
 
     public uint? ActivePanelId => _activePanel;
 
+    public void ConfigureMainPanelFrame(ElementInfo frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        if (_byPanel.Count != 0)
+            throw new InvalidOperationException("Configure the shared frame before registering panels.");
+        _mainPanelFrame = frame;
+    }
+
     public void RegisterMainPanel(
         uint panelId,
         string windowName,
@@ -42,6 +51,27 @@ public sealed class RetailPanelUiController : IDisposable
             throw new ArgumentException(
                 $"Panel window name '{windowName}' does not match handle '{window.Name}'.",
                 nameof(windowName));
+
+        if (_mainPanelFrame is { } shared)
+        {
+            var frame = window.OuterFrame;
+            frame.MinWidth = shared.MinWidth ?? shared.Width;
+            frame.MaxWidth = shared.MaxWidth ?? shared.Width;
+            frame.MinHeight = shared.MinHeight ?? shared.Height;
+            frame.MaxHeight = shared.MaxHeight ?? float.MaxValue;
+            frame.Resizable = true;
+            frame.ResizeX = true;
+            frame.ResizeY = true;
+            frame.ResizableEdges = ResizeEdges.Bottom;
+            bool constrained = frame.ConstrainResizeToParent;
+            frame.ConstrainResizeToParent = false;
+            try { window.ResizeTo(shared.Width, shared.Height); }
+            finally
+            {
+                frame.ResizeX = false;
+                frame.ConstrainResizeToParent = constrained;
+            }
+        }
 
         RegisterCore(
             panelId,
@@ -277,14 +307,19 @@ public sealed class RetailPanelUiController : IDisposable
         }
     }
 
-    private static void ApplyWindowGeometry(PanelEntry entry, PanelGeometry geometry)
+    private void ApplyWindowGeometry(PanelEntry entry, PanelGeometry geometry)
     {
         if (entry.Window is not { } window) return;
-
-        if (window.Left != geometry.Left || window.Top != geometry.Top)
-            window.MoveTo(geometry.Left, geometry.Top);
-        if (window.Width != geometry.Width || window.Height != geometry.Height)
-            window.ResizeTo(geometry.Width, geometry.Height);
+        bool synchronizing = _synchronizingGeometry;
+        _synchronizingGeometry = true;
+        try
+        {
+            if (window.Left != geometry.Left || window.Top != geometry.Top)
+                window.MoveTo(geometry.Left, geometry.Top);
+            if (window.Width != geometry.Width || window.Height != geometry.Height)
+                window.ResizeTo(geometry.Width, geometry.Height);
+        }
+        finally { _synchronizingGeometry = synchronizing; }
     }
 
     public void Dispose()

--- a/src/AcDream.App/UI/Layout/SalvageUiController.cs
+++ b/src/AcDream.App/UI/Layout/SalvageUiController.cs
@@ -1,0 +1,293 @@
+using AcDream.Core.Items;
+
+namespace AcDream.App.UI.Layout;
+
+public sealed class SalvageUiController : IRetainedPanelController, IItemListDragHandler
+{
+    public const uint LayoutId = 0x2100000Cu;
+    public const uint RootId = 0x10000073u;
+    public const uint ItemListId = 0x10000074u;
+    public const uint ScrollbarId = 0x10000075u;
+    public const uint SalvageButtonId = 0x10000076u;
+    public const uint CloseButtonId = 0x10000078u;
+    private const uint TradeOverlaySprite = 0x06001DAEu;
+
+    public sealed record Bindings(
+        ClientObjectTable Objects,
+        Func<uint, bool> IsOwned,
+        Func<uint, IReadOnlyList<uint>, bool> SendSalvage,
+        Func<bool> AllowMultipleMaterials,
+        Func<ItemType, uint, uint, uint, uint, uint> ResolveIcon,
+        Action<bool> SetWindowVisible,
+        Action<string> Report,
+        uint EmptySlotSprite = 0u);
+
+    private readonly Bindings _bindings;
+    private readonly UiItemList _list;
+    private readonly UiButton _salvageButton;
+    private readonly UiButton? _closeButton;
+    private readonly List<ClientObject> _items = [];
+    private uint _toolId;
+    private uint _material;
+    private bool _disposed;
+    private bool _sending;
+
+    private SalvageUiController(ImportedLayout layout, Bindings bindings)
+    {
+        _bindings = bindings;
+        _list = (UiItemList)layout.FindElement(ItemListId)!;
+        _salvageButton = (UiButton)layout.FindElement(SalvageButtonId)!;
+        _closeButton = layout.FindElement(CloseButtonId) as UiButton;
+        _list.Columns = 1;
+        _list.SingleRow = true;
+        _list.HorizontalScroll = true;
+        _list.CellWidth = 32f;
+        _list.CellHeight = 32f;
+        _list.FillVisibleEmptySlots = true;
+        _list.CellEmptySprite = bindings.EmptySlotSprite;
+        _list.EmptySlotFactory = () => new UiItemSlot
+        {
+            SpriteResolve = _list.SpriteResolve,
+            AllowDragSource = false,
+        };
+        _list.RegisterDragHandler(this);
+        if (layout.FindElement(ScrollbarId) is UiScrollbar scrollbar)
+        {
+            scrollbar.Model = _list.Scroll;
+            scrollbar.Horizontal = true;
+        }
+        _list.ExamineItemRequested = RemoveItem;
+        _salvageButton.SuppressSelfToggle = true;
+        _salvageButton.OnClick = () => Salvage();
+        if (_closeButton is not null) _closeButton.OnClick = Close;
+        bindings.Objects.ObjectRemoved += OnObjectRemoved;
+        bindings.Objects.ObjectUpdated += OnObjectChanged;
+        bindings.Objects.ObjectMoved += OnObjectMoved;
+        bindings.Objects.ContainerContentsReplaced += OnContainerContentsReplaced;
+        bindings.Objects.Cleared += Close;
+        Refresh();
+    }
+
+    public static SalvageUiController? Bind(ImportedLayout layout, Bindings bindings)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        ArgumentNullException.ThrowIfNull(bindings);
+        return layout.FindElement(ItemListId) is UiItemList
+            && layout.FindElement(SalvageButtonId) is UiButton
+                ? new SalvageUiController(layout, bindings) : null;
+    }
+
+    public int ItemCount => _items.Count;
+    public uint ToolId => _toolId;
+
+    public void HandlePolicyAction(ItemPolicyAction action)
+    {
+        if (action.Kind == ItemPolicyActionKind.OpenSalvage)
+            Open(action.ObjectId);
+    }
+
+    public void Open(uint toolId)
+    {
+        if (_disposed || !IsToolAvailable(toolId)) return;
+        ClearItems();
+        _toolId = toolId;
+        Refresh();
+        _bindings.SetWindowVisible(true);
+    }
+
+    private bool IsToolAvailable(uint toolId) => toolId != 0u
+        && _bindings.IsOwned(toolId)
+        && _bindings.Objects.Get(toolId) is { } tool
+        && (tool.Type & ItemType.TinkeringTool) != 0;
+
+    public bool CanAdd(uint itemId)
+    {
+        if (_disposed || _sending || !IsToolAvailable(_toolId)
+            || itemId == _toolId || !_bindings.IsOwned(itemId)
+            || _items.Any(item => item.ObjectId == itemId)
+            || _bindings.Objects.Get(itemId) is not { } item)
+            return false;
+        return _bindings.Objects.GetContents(itemId).Count > 0
+            || SalvageItemPolicy.IsSuitable(item, _material, _bindings.AllowMultipleMaterials());
+    }
+
+    public bool AddItem(uint itemId)
+    {
+        if (!CanAdd(itemId)) return false;
+        var visited = new HashSet<uint>();
+        AddRecursive(itemId, visited);
+        Refresh();
+        return true;
+    }
+
+    private void AddRecursive(uint itemId, HashSet<uint> visited)
+    {
+        if (!visited.Add(itemId) || !CanAdd(itemId)) return;
+        IReadOnlyList<uint> contents = _bindings.Objects.GetContents(itemId);
+        if (contents.Count > 0)
+        {
+            _bindings.Report($"Adding contents of {_bindings.Objects.Get(itemId)!.GetAppropriateName()}");
+            foreach (uint child in contents)
+                AddRecursive(child, visited);
+            return;
+        }
+        ClientObject item = _bindings.Objects.Get(itemId)!;
+        item.TradeState = 1;
+        _items.Add(item);
+        if (_items.Count == 1) _material = item.MaterialType ?? 0u;
+    }
+
+    public void RemoveItem(uint itemId)
+    {
+        int index = _items.FindIndex(item => item.ObjectId == itemId);
+        if (index < 0) return;
+        _items[index].TradeState = 0;
+        _items.RemoveAt(index);
+        if (_items.Count == 0) _material = 0;
+        Refresh();
+    }
+
+    public bool Salvage()
+    {
+        if (_disposed || _sending || _items.Count == 0 || !IsToolAvailable(_toolId)) return false;
+        if (_items.Any(item => !_bindings.IsOwned(item.ObjectId)
+            || !ReferenceEquals(item, _bindings.Objects.Get(item.ObjectId))
+            || !SalvageItemPolicy.IsSuitable(item)))
+        {
+            _bindings.Report("The list of items you are attempting to salvage is invalid.");
+            return false;
+        }
+        uint[] itemIds = _items.AsEnumerable().Reverse().Select(item => item.ObjectId).ToArray();
+        _sending = true;
+        try
+        {
+            foreach (ClientObject item in _items) item.TradeState = 0;
+            if (!_bindings.SendSalvage(_toolId, itemIds))
+            {
+                foreach (ClientObject item in _items) item.TradeState = 1;
+                _bindings.Report("You cannot salvage those items right now.");
+                return false;
+            }
+            ClearItems();
+            Refresh();
+            return true;
+        }
+        finally { _sending = false; }
+    }
+
+    public void Close()
+    {
+        OnHidden();
+        _bindings.SetWindowVisible(false);
+    }
+
+    public void OnHidden()
+    {
+        _toolId = 0;
+        ClearItems();
+        Refresh();
+    }
+
+    private void ClearItems()
+    {
+        foreach (ClientObject item in _items) item.TradeState = 0;
+        _items.Clear();
+        _material = 0;
+    }
+
+    private void Refresh()
+    {
+        using (_list.DeferLayout())
+        {
+            _list.Flush();
+            foreach (ClientObject item in _items)
+            {
+                var slot = new UiItemSlot
+                {
+                    SlotIndex = _list.GetNumUIItems(),
+                    SpriteResolve = _list.SpriteResolve,
+                    AllowDragSource = true,
+                    SourceKind = ItemDragSource.Inventory,
+                    ShowTradeOverlay = true,
+                    TradeOverlaySprite = TradeOverlaySprite,
+                    TooltipTextResolve = id => _bindings.Objects.Get(id)?.GetTooltipDisplayName(),
+                };
+                slot.SetItem(item.ObjectId, _bindings.ResolveIcon(
+                    item.Type, item.IconId, item.IconUnderlayId, item.IconOverlayId, item.Effects));
+                slot.SetStructure(item.Structure, item.MaxStructure);
+                _list.AddItem(slot);
+            }
+        }
+        _salvageButton.Enabled = _items.Count > 0;
+    }
+
+    private void OnObjectRemoved(ClientObject item)
+    {
+        if (item.ObjectId == _toolId) Close();
+        else RemoveItem(item.ObjectId);
+    }
+
+    private void OnObjectChanged(ClientObject item)
+    {
+        if (item.ObjectId == _toolId && !IsToolAvailable(_toolId)) { Close(); return; }
+        if (!_items.Any(staged => staged.ObjectId == item.ObjectId)) return;
+        if (!_bindings.IsOwned(item.ObjectId) || !SalvageItemPolicy.IsSuitable(item)
+            || !_items.Any(staged => ReferenceEquals(staged, item))) RemoveItem(item.ObjectId);
+        else Refresh();
+    }
+
+    private void OnObjectMoved(ClientObjectMove move)
+    {
+        RevalidateOwnership();
+    }
+
+    private void OnContainerContentsReplaced(uint containerId) => RevalidateOwnership();
+
+    private void RevalidateOwnership()
+    {
+        if (_toolId == 0) return;
+        if (!IsToolAvailable(_toolId)) { Close(); return; }
+        // Moving a container can change ownership of every staged item inside it.
+        for (int index = _items.Count - 1; index >= 0; index--)
+        {
+            ClientObject item = _items[index];
+            if (!_bindings.IsOwned(item.ObjectId)
+                || !ReferenceEquals(item, _bindings.Objects.Get(item.ObjectId)))
+            {
+                item.TradeState = 0;
+                _items.RemoveAt(index);
+            }
+        }
+        if (_items.Count == 0) _material = 0;
+        Refresh();
+    }
+
+    public void OnDragLift(UiItemList sourceList, UiItemSlot sourceCell, ItemDragPayload payload)
+    {
+        if (ReferenceEquals(sourceList, _list)) RemoveItem(payload.ObjId);
+    }
+
+    public ItemDragAcceptance OnDragOver(UiItemList targetList, UiItemSlot targetCell, ItemDragPayload payload)
+        => ReferenceEquals(targetList, _list) && payload.SourceKind == ItemDragSource.Inventory && CanAdd(payload.ObjId)
+            ? ItemDragAcceptance.Accept : ItemDragAcceptance.Reject;
+
+    public void HandleDropRelease(UiItemList targetList, UiItemSlot targetCell, ItemDragPayload payload)
+    {
+        if (OnDragOver(targetList, targetCell, payload) == ItemDragAcceptance.Accept) AddItem(payload.ObjId);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _bindings.Objects.ObjectRemoved -= OnObjectRemoved;
+        _bindings.Objects.ObjectUpdated -= OnObjectChanged;
+        _bindings.Objects.ObjectMoved -= OnObjectMoved;
+        _bindings.Objects.ContainerContentsReplaced -= OnContainerContentsReplaced;
+        _bindings.Objects.Cleared -= Close;
+        OnHidden();
+        _salvageButton.OnClick = null;
+        if (_closeButton is not null) _closeButton.OnClick = null;
+        _list.ExamineItemRequested = null;
+    }
+}

--- a/src/AcDream.App/UI/Layout/SelectedObjectController.cs
+++ b/src/AcDream.App/UI/Layout/SelectedObjectController.cs
@@ -263,12 +263,7 @@ public sealed class SelectedObjectController : IRetainedPanelController
         uint g = guid.Value;
 
         uint stackSize = _stackSize(g);
-        string? objectName = _resolveName(g);
-        _currentName = _isCoinstack(g) && _isOwnedByPlayer(g)
-            ? $"{stackSize} {objectName} (of {_coinTotal()})"
-            : stackSize > 1u && !string.IsNullOrEmpty(objectName)
-                ? $"{stackSize} {objectName}"
-                : objectName;
+        RefreshName(g, stackSize);
 
         SetOverlayState(stackSize > 1u
             ? RetailUiStateIds.StackedItemSelected
@@ -397,8 +392,23 @@ public sealed class SelectedObjectController : IRetainedPanelController
 
     private void OnObjectUpdated(ClientObject updated)
     {
-        if (_current == updated.ObjectId && _stackSize(updated.ObjectId) != _splitQuantity.Maximum)
+        if (_current != updated.ObjectId)
+            return;
+        uint stackSize = _stackSize(updated.ObjectId);
+        if (stackSize != _splitQuantity.Maximum)
             ApplySelection(updated.ObjectId);
+        else
+            RefreshName(updated.ObjectId, stackSize);
+    }
+
+    private void RefreshName(uint guid, uint stackSize)
+    {
+        string? objectName = _resolveName(guid);
+        _currentName = _isCoinstack(guid) && _isOwnedByPlayer(guid)
+            ? $"{stackSize} {objectName} (of {_coinTotal()})"
+            : stackSize > 1u && !string.IsNullOrEmpty(objectName)
+                ? $"{stackSize} {objectName}"
+                : objectName;
     }
 
     private void OnSelectionTransition(SelectionTransition transition)

--- a/src/AcDream.App/UI/RetailUiRuntime.cs
+++ b/src/AcDream.App/UI/RetailUiRuntime.cs
@@ -323,6 +323,29 @@ public sealed record RetailUiRuntimeBindings(
 public sealed class RetailUiRuntime : IDisposable
 {
     private readonly RetailUiRuntimeBindings _bindings;
+    private CreatureDisplayNameResolver? _creatureNames;
+    private RetailAppraisalNameResolver? _itemNames;
+
+    private RetailAppraisalNameResolver ItemNames
+    {
+        get
+        {
+            if (_itemNames is not null)
+                return _itemNames;
+            lock (_bindings.Assets.DatLock)
+            {
+                _creatureNames ??= CreatureDisplayNameResolver.Load(_bindings.Assets.Dats);
+                return _itemNames ??= RetailAppraisalNameResolver.Load(
+                    _bindings.Assets.Dats, _creatureNames);
+            }
+        }
+    }
+
+    private string? ResolveSelectedObjectName(uint guid) =>
+        _bindings.Toolbar.Objects.Get(guid) is { } obj
+            ? ItemNames.ResolveAppropriateName(obj)
+            : _bindings.Toolbar.ResolveName(guid);
+
     private StackSplitQuantityState StackSplitQuantity => _bindings.StackSplitQuantity;
     private RetailWindowLayoutPersistence? _persistence;
     private RetailUiAutomationScriptRunner? _automation;
@@ -413,6 +436,7 @@ public sealed class RetailUiRuntime : IDisposable
         MountExternalContainer();
         MountVendor();
         MountSecureTrade();
+        MountSalvage();
         MountItemCooldowns();
         if (bindings.Connection is { } connection)
         {
@@ -443,6 +467,7 @@ public sealed class RetailUiRuntime : IDisposable
                     WindowNames.Vitals,
                     WindowNames.SideVitals,
                     WindowNames.SecureTrade,
+                    WindowNames.Salvage,
                     WindowNames.PluginShelf,
                 ]);
             _persistence.ResetToDefaults();
@@ -685,6 +710,9 @@ public sealed class RetailUiRuntime : IDisposable
 
     public bool HandleInputAction(AcDream.UI.Abstractions.Input.InputAction action)
     {
+        if (AppraisalController?.HandleInputAction(action) == true)
+            return true;
+
         if (SpellcastingUiController?.Handle(action) == true)
             return true;
 
@@ -1549,7 +1577,7 @@ public sealed class RetailUiRuntime : IDisposable
             handler => b.ItemMana.ItemManaChanged -= handler,
             b.IsHealthTarget,
             b.ItemInteraction.IsOwnedByPlayer,
-            b.ResolveName,
+            ResolveSelectedObjectName,
             b.HealthPercent,
             b.HasHealth,
             b.StackSize,
@@ -1809,11 +1837,8 @@ public sealed class RetailUiRuntime : IDisposable
                     _bindings.Assets.ResolveSprite,
                     _bindings.Assets.DefaultFont,
                     _bindings.Assets.ResolveFont);
-            creatureNames = CreatureDisplayNameResolver.Load(
-                _bindings.Assets.Dats);
-            itemNames = RetailAppraisalNameResolver.Load(
-                _bindings.Assets.Dats,
-                creatureNames);
+            itemNames = ItemNames;
+            creatureNames = _creatureNames;
         }
         if (layout is null)
         {
@@ -4015,6 +4040,71 @@ public sealed class RetailUiRuntime : IDisposable
 
     public Layout.SecureTradeUiController? SecureTradeController { get; private set; }
 
+    public SalvageUiController? SalvageController { get; private set; }
+
+    private void MountSalvage()
+    {
+        ImportedLayout? layout;
+        uint emptySlot;
+        lock (_bindings.Assets.DatLock)
+        {
+            layout = LayoutImporter.Import(
+                _bindings.Assets.Dats, SalvageUiController.LayoutId, SalvageUiController.RootId,
+                _bindings.Assets.ResolveSprite, _bindings.Assets.DefaultFont, _bindings.Assets.ResolveFont);
+            emptySlot = ItemListCellTemplate.ResolveEmptySprite(
+                _bindings.Assets.Dats, SalvageUiController.LayoutId, SalvageUiController.ItemListId);
+        }
+        if (layout is null)
+        {
+            Console.WriteLine("[UI] salvage window layout is unavailable.");
+            return;
+        }
+        InventoryRuntimeBindings inventory = _bindings.Inventory;
+        SalvageUiController? controller = SalvageUiController.Bind(layout,
+            new SalvageUiController.Bindings(
+                inventory.Objects,
+                inventory.ItemInteraction.IsOwnedByPlayer,
+                inventory.ItemInteraction.TrySalvageItems,
+                () => _bindings.Options.CurrentCharacterOption((uint)CharacterOptionId.SalvageMultiple),
+                inventory.ResolveIcon,
+                visible =>
+                {
+                    if (visible) Host.ShowWindow(WindowNames.Salvage);
+                    else Host.HideWindow(WindowNames.Salvage);
+                },
+                _bindings.Options.DisplaySystemMessage,
+                emptySlot));
+        if (controller is null)
+        {
+            Console.WriteLine("[UI] salvage window controls are unavailable.");
+            return;
+        }
+        UiElement root = layout.Root;
+        const float frameInset = 2f * RetailChromeSprites.Border;
+        float width = MathF.Min(root.Width, MathF.Max(240f, Host.Root.Width - frameInset));
+        RetailWindowFrame.Mount(Host.Root, root, _bindings.Assets.ResolveSprite,
+            new RetailWindowFrame.Options
+            {
+                WindowName = WindowNames.Salvage,
+                Chrome = RetailWindowChrome.NineSlice,
+                Left = MathF.Max(0f, (Host.Root.Width - width - frameInset) * 0.5f),
+                Top = MathF.Max(0f, (Host.Root.Height - root.Height - frameInset) * 0.5f),
+                ContentWidth = width,
+                ContentHeight = root.Height,
+                MinWidth = 240f,
+                MinHeight = root.Height,
+                Visible = false,
+                ResizeX = true,
+                ResizeY = false,
+                ResizableEdges = ResizeEdges.Left | ResizeEdges.Right,
+                ConstrainDragToParent = true,
+                ConstrainResizeToParent = true,
+                Controller = controller,
+            });
+        SalvageController = controller;
+        inventory.ItemInteraction.PolicyActionRequested += controller.HandlePolicyAction;
+    }
+
     private void MountSecureTrade()
     {
         if (_bindings.Social.Trade is not { } tradeView)
@@ -4602,6 +4692,8 @@ public sealed class RetailUiRuntime : IDisposable
                     _bindings.Inventory.ItemInteraction.SecureTradeRequested -=
                         trade.RequestSecureTrade;
                 }
+                if (SalvageController is { } salvage)
+                    _bindings.Inventory.ItemInteraction.PolicyActionRequested -= salvage.HandlePolicyAction;
             },
             () => _itemConfirmationController?.Dispose(),
             () =>

--- a/src/AcDream.App/UI/RetailUiRuntime.cs
+++ b/src/AcDream.App/UI/RetailUiRuntime.cs
@@ -378,6 +378,13 @@ public sealed class RetailUiRuntime : IDisposable
     private void Initialize()
     {
         RetailUiRuntimeBindings bindings = _bindings;
+        lock (_bindings.Assets.DatLock)
+        {
+            ElementInfo? mainPanelFrame = LayoutImporter.ImportInfos(
+                _bindings.Assets.Dats, 0x2100006Eu, 0x100005FEu);
+            if (mainPanelFrame is not null)
+                _panelUi.ConfigureMainPanelFrame(mainPanelFrame);
+        }
         MountFpsDisplay();
         MountVividTargetIndicator();
         MountProjectileDebugOverlay();

--- a/src/AcDream.App/UI/UiItemSlot.cs
+++ b/src/AcDream.App/UI/UiItemSlot.cs
@@ -45,6 +45,15 @@ public class UiItemSlot : UiElement
     public uint CapacityBackSprite { get; set; } = 0x06004D22u;
     public uint CapacityFrontSprite { get; set; } = 0x06004D23u;
 
+    public float StructureFill { get; set; } = -1f;
+    public uint StructureBackSprite { get; set; } = 0x06004D24u;
+    public uint StructureFrontSprite { get; set; } = 0x06004D25u;
+
+    public void SetStructure(int structure, int maxStructure)
+        => StructureFill = maxStructure > 0 && structure < maxStructure
+            ? Math.Clamp(structure / (float)maxStructure, 0f, 1f)
+            : -1f;
+
     public enum DragAcceptState { None, Accept, Reject }
     private DragAcceptState _dragAccept = DragAcceptState.None;
     internal DragAcceptState DragAcceptVisual => _dragAccept;
@@ -244,26 +253,11 @@ public class UiItemSlot : UiElement
 
         DrawShortcutOverlay(ctx);
 
-        if (CapacityFill >= 0f && SpriteResolve is not null)
-        {
-            const float by = 1f, bw = 5f, bh = 30f;
-            float bx = Width - bw;
-            if (CapacityBackSprite != 0)
-            {
-                var (bt, _, _) = SpriteResolve(CapacityBackSprite);
-                if (bt != 0) ctx.DrawSprite(bt, bx, by, bw, bh, 0f, 0f, 1f, 1f, Vector4.One);
-            }
-            float f = Math.Clamp(CapacityFill, 0f, 1f);
-            if (f > 0f && CapacityFrontSprite != 0)
-            {
-                var (ft, _, _) = SpriteResolve(CapacityFrontSprite);
-                if (ft != 0)
-                {
-                    float fh = bh * f;
-                    ctx.DrawSprite(ft, bx, by + (bh - fh), bw, fh, 0f, 1f - f, 1f, 1f, Vector4.One);
-                }
-            }
-        }
+        DrawMeter(ctx, CapacityFill, CapacityBackSprite, CapacityFrontSprite);
+
+        // Full structure hides its meter; depleted structure retains the empty rail.
+        if (StructureFill is >= 0f and < 1f)
+            DrawMeter(ctx, StructureFill, StructureBackSprite, StructureFrontSprite);
 
         if (_waiting && SpriteResolve is not null && WaitingSprite != 0)
         {
@@ -303,6 +297,30 @@ public class UiItemSlot : UiElement
                     1f,
                     1f,
                     Vector4.One);
+        }
+    }
+
+    private void DrawMeter(UiRenderContext ctx, float fill, uint backSprite, uint frontSprite)
+    {
+        if (fill < 0f || SpriteResolve is null)
+            return;
+
+        const float by = 1f, bw = 5f, bh = 30f;
+        float bx = Width - bw;
+        if (backSprite != 0)
+        {
+            var (bt, _, _) = SpriteResolve(backSprite);
+            if (bt != 0) ctx.DrawSprite(bt, bx, by, bw, bh, 0f, 0f, 1f, 1f, Vector4.One);
+        }
+        float f = Math.Clamp(fill, 0f, 1f);
+        if (f > 0f && frontSprite != 0)
+        {
+            var (ft, _, _) = SpriteResolve(frontSprite);
+            if (ft != 0)
+            {
+                float fh = bh * f;
+                ctx.DrawSprite(ft, bx, by + (bh - fh), bw, fh, 0f, 1f - f, 1f, 1f, Vector4.One);
+            }
         }
     }
 

--- a/src/AcDream.App/UI/WindowNames.cs
+++ b/src/AcDream.App/UI/WindowNames.cs
@@ -28,6 +28,7 @@ public static class WindowNames
     public const string Examination = "examination";
     public const string Vendor = "vendor";
     public const string SecureTrade = "secure-trade";
+    public const string Salvage = "salvage";
     public const string Options = "options";
     public const string KeyboardConfig = "keyboard-config";
 

--- a/src/AcDream.App/Update/LiveObjectFrameController.cs
+++ b/src/AcDream.App/Update/LiveObjectFrameController.cs
@@ -120,6 +120,39 @@ internal sealed class LiveEffectFrameController
     }
 }
 
+internal sealed class SkyPesActivationGateSlot : ISkyPesActivationGate
+{
+    private ISkyPesActivationGate? _gate;
+
+    public IDisposable BindOwned(ISkyPesActivationGate gate)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        if (_gate is not null)
+            throw new InvalidOperationException("Sky presentation effects are already bound.");
+
+        _gate = gate;
+        return new Binding(this, gate);
+    }
+
+    public void Tick() => _gate?.Tick();
+
+    private void Unbind(ISkyPesActivationGate expected)
+    {
+        if (ReferenceEquals(_gate, expected))
+            _gate = null;
+    }
+
+    private sealed class Binding(
+        SkyPesActivationGateSlot slot,
+        ISkyPesActivationGate expected) : IDisposable
+    {
+        private SkyPesActivationGateSlot? _slot = slot;
+
+        public void Dispose() =>
+            Interlocked.Exchange(ref _slot, null)?.Unbind(expected);
+    }
+}
+
 internal sealed class LiveObjectFrameController : ILiveObjectFramePhase
 {
     private readonly RetailInboundEventDispatcher _inboundEvents;
@@ -135,6 +168,7 @@ internal sealed class LiveObjectFrameController : ILiveObjectFramePhase
         _animatedEntities;
     private readonly EquippedChildRenderController _equippedChildren;
     private readonly LiveEffectFrameController _effects;
+    private readonly SkyPesActivationGateSlot _skyPesActivation = new();
     private readonly ILiveRenderProjectionSink? _renderProjections;
     private readonly StaticRenderProjectionJournal? _staticRenderProjections;
     private readonly List<WorldEntity> _activeStaticProjectionScratch = [];
@@ -182,6 +216,9 @@ internal sealed class LiveObjectFrameController : ILiveObjectFramePhase
             deltaSeconds,
             static (controller, elapsed) => controller.TickCore(elapsed));
 
+    public IDisposable BindSkyPesActivationGateOwned(ISkyPesActivationGate gate) =>
+        _skyPesActivation.BindOwned(gate);
+
     private void TickCore(float deltaSeconds)
     {
         _localPlayerFrame.AdvanceBeforeNetwork(deltaSeconds);
@@ -215,6 +252,7 @@ internal sealed class LiveObjectFrameController : ILiveObjectFramePhase
                 _activeStaticProjectionScratch);
         }
         _staticAnimations.ProcessHooks();
+        _skyPesActivation.Tick();
         _effects.Tick(deltaSeconds);
     }
 }

--- a/src/AcDream.Core.Net/GameEventWiring.cs
+++ b/src/AcDream.Core.Net/GameEventWiring.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using AcDream.Core.Chat;
 using AcDream.Core.Combat;
@@ -719,6 +720,43 @@ public static class GameEventWiring
                 chat.OnSystemMessage(text, chatType: (uint)type);
         });
 
+        registrar.Register(GameEventType.SalvageOperationsResult, e =>
+        {
+            var result = GameEvents.ParseSalvageOperationsResult(e.Payload.Span);
+            if (result is null)
+                return;
+
+            if (result.Value.Results.Count != 0)
+            {
+                string text = FormatSalvageResults(result.Value);
+                if (onInterfaceText is not null)
+                    onInterfaceText(text, RetailLogTextType.Salvaging);
+                else
+                    chat.OnSystemMessage(text, (uint)RetailLogTextType.Salvaging);
+            }
+
+            if (result.Value.UnsuitableItemGuids.Count != 0)
+            {
+                string names = string.Join(", ", result.Value.UnsuitableItemGuids
+                    .Select(id => items.Get(id)?.GetAppropriateName() ?? "item"));
+                string text = $" The following were not suitable for salvaging: {names}";
+                if (onInterfaceText is not null)
+                    onInterfaceText(text, RetailLogTextType.Salvaging);
+                else
+                    chat.OnSystemMessage(text, (uint)RetailLogTextType.Salvaging);
+            }
+
+            if (result.Value.Results.Count == 0
+                && result.Value.UnsuitableItemGuids.Count == 0)
+            {
+                const string text = "Salvaging Failed!";
+                if (onInterfaceText is not null)
+                    onInterfaceText(text, RetailLogTextType.Salvaging);
+                else
+                    chat.OnSystemMessage(text, (uint)RetailLogTextType.Salvaging);
+            }
+        });
+
         registrar.Register(GameEventType.CloseGroundContainer, e =>
         {
             var guid = GameEvents.ParseCloseGroundContainer(e.Payload.Span);
@@ -962,4 +1000,76 @@ public static class GameEventWiring
         if ((statModType & Additive) != 0) return 2u;
         return 0u;
     }
+
+    private static string FormatSalvageResults(GameEvents.SalvageOperationsResult result)
+    {
+        string materials = string.Join(", ", result.Results.Select(FormatSalvageMaterial));
+        string augmentation = result.AugmentationBonusPercent == 0
+            ? string.Empty
+            : string.Format(
+                CultureInfo.InvariantCulture,
+                " Your augmentation has given you a return bonus of {0}%!",
+                result.AugmentationBonusPercent);
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "You obtain {0} using your knowledge of {1}.{2}",
+            materials,
+            SalvageSkillName(result.SkillId),
+            augmentation);
+    }
+
+    private static string FormatSalvageMaterial(GameEvents.SalvageResult result) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} {1} (ws {2:F2})",
+            result.Units,
+            SalvageMaterialName(result.MaterialType),
+            result.Workmanship);
+
+    private static string SalvageMaterialName(uint materialType) => materialType switch
+    {
+        1u => "Ceramic", 2u => "Porcelain", 3u => "Cloth", 4u => "Linen",
+        5u => "Satin", 6u => "Silk", 7u => "Velvet", 8u => "Wool",
+        9u => "Gem", 10u => "Agate", 11u => "Amber", 12u => "Amethyst",
+        13u => "Aquamarine", 14u => "Azurite", 15u => "Black Garnet",
+        16u => "Black Opal", 17u => "Bloodstone", 18u => "Carnelian",
+        19u => "Citrine", 20u => "Diamond", 21u => "Emerald", 22u => "Fire Opal",
+        23u => "Green Garnet", 24u => "Green Jade", 25u => "Hematite",
+        26u => "Imperial Topaz", 27u => "Jet", 28u => "Lapis Lazuli",
+        29u => "Lavender Jade", 30u => "Malachite", 31u => "Moonstone",
+        32u => "Onyx", 33u => "Opal", 34u => "Peridot", 35u => "Red Garnet",
+        36u => "Red Jade", 37u => "Rose Quartz", 38u => "Ruby", 39u => "Sapphire",
+        40u => "Smokey Quartz", 41u => "Sunstone", 42u => "Tiger Eye",
+        43u => "Tourmaline", 44u => "Turquoise", 45u => "White Jade",
+        46u => "White Quartz", 47u => "White Sapphire", 48u => "Yellow Garnet",
+        49u => "Yellow Topaz", 50u => "Zircon", 51u => "Ivory", 52u => "Leather",
+        53u => "Armoredillo Hide", 54u => "Gromnie Hide", 55u => "Reed Shark Hide",
+        56u => "Metal", 57u => "Brass", 58u => "Bronze", 59u => "Copper",
+        60u => "Gold", 61u => "Iron", 62u => "Pyreal", 63u => "Silver",
+        64u => "Steel", 65u => "Stone", 66u => "Alabaster", 67u => "Granite",
+        68u => "Marble", 69u => "Obsidian", 70u => "Sandstone", 71u => "Serpentine",
+        72u => "Wood", 73u => "Ebony", 74u => "Mahogany", 75u => "Oak",
+        76u => "Pine", 77u => "Teak", _ => "Unknown",
+    };
+
+    private static string SalvageSkillName(uint skillId) => skillId switch
+    {
+        1u => "Axe", 2u => "Bow", 3u => "Crossbow", 4u => "Dagger", 5u => "Mace",
+        6u => "Melee Defense", 7u => "Missile Defense", 8u => "Sling", 9u => "Spear",
+        10u => "Staff", 11u => "Sword", 12u => "Thrown Weapon", 13u => "Unarmed Combat",
+        14u => "Arcane Lore", 15u => "Magic Defense", 16u => "Mana Conversion",
+        17u => "Spellcraft", 18u => "Item Tinkering", 19u => "Assess Person",
+        20u => "Deception", 21u => "Healing", 22u => "Jump", 23u => "Lockpick",
+        24u => "Run", 25u => "Awareness", 26u => "Arms And Armor Repair",
+        27u => "Assess Creature", 28u => "Weapon Tinkering", 29u => "Armor Tinkering",
+        30u => "Magic Item Tinkering", 31u => "Creature Enchantment",
+        32u => "Item Enchantment", 33u => "Life Magic", 34u => "War Magic",
+        35u => "Leadership", 36u => "Loyalty", 37u => "Fletching", 38u => "Alchemy",
+        39u => "Cooking", 40u => "Salvaging", 41u => "Two Handed Combat",
+        42u => "Gearcraft", 43u => "Void Magic", 44u => "Heavy Weapons",
+        45u => "Light Weapons", 46u => "Finesse Weapons", 47u => "Missile Weapons",
+        48u => "Shield", 49u => "Dual Wield", 50u => "Recklessness",
+        51u => "Sneak Attack", 52u => "Dirty Fighting", 53u => "Challenge",
+        54u => "Summoning", _ => "Unknown",
+    };
 }

--- a/src/AcDream.Core.Net/Messages/GameEvents.cs
+++ b/src/AcDream.Core.Net/Messages/GameEvents.cs
@@ -390,6 +390,59 @@ public static class GameEvents
             BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(4)));
     }
 
+    public readonly record struct SalvageResult(
+        uint MaterialType,
+        double Workmanship,
+        uint Units);
+
+    public readonly record struct SalvageOperationsResult(
+        uint SkillId,
+        IReadOnlyList<uint> UnsuitableItemGuids,
+        IReadOnlyList<SalvageResult> Results,
+        int AugmentationBonusPercent);
+
+    public static SalvageOperationsResult? ParseSalvageOperationsResult(
+        ReadOnlySpan<byte> payload)
+    {
+        const int ResultSize = 16;
+        int position = 0;
+        if (payload.Length < 16)
+            return null;
+
+        uint skillId = BinaryPrimitives.ReadUInt32LittleEndian(payload); position += 4;
+        uint unsuitableCount = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position)); position += 4;
+        if (unsuitableCount > (uint)((payload.Length - position) / sizeof(uint)))
+            return null;
+
+        var unsuitable = new uint[(int)unsuitableCount];
+        for (int index = 0; index < unsuitable.Length; index++)
+        {
+            unsuitable[index] = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position));
+            position += sizeof(uint);
+        }
+
+        if (payload.Length - position < sizeof(uint) + sizeof(int))
+            return null;
+        uint resultCount = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position));
+        position += sizeof(uint);
+        if (resultCount > (uint)((payload.Length - position - sizeof(int)) / ResultSize))
+            return null;
+
+        var results = new SalvageResult[(int)resultCount];
+        for (int index = 0; index < results.Length; index++)
+        {
+            uint materialType = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position)); position += 4;
+            double workmanship = BinaryPrimitives.ReadDoubleLittleEndian(payload.Slice(position)); position += 8;
+            uint units = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position)); position += 4;
+            results[index] = new SalvageResult(materialType, workmanship, units);
+        }
+
+        if (payload.Length - position < sizeof(int))
+            return null;
+        int augmentationBonus = BinaryPrimitives.ReadInt32LittleEndian(payload.Slice(position));
+        return new SalvageOperationsResult(skillId, unsuitable, results, augmentationBonus);
+    }
+
     public static uint? ParseCloseGroundContainer(ReadOnlySpan<byte> payload)
     {
         if (payload.Length < 4) return null;

--- a/src/AcDream.Core/Items/SalvageItemPolicy.cs
+++ b/src/AcDream.Core/Items/SalvageItemPolicy.cs
@@ -1,0 +1,17 @@
+namespace AcDream.Core.Items;
+
+public static class SalvageItemPolicy
+{
+    public static bool IsValidMaterial(uint material) => material is
+        1 or 2 or >= 4 and <= 8 or >= 10 and <= 55 or >= 57 and <= 64
+        or >= 66 and <= 71 or >= 73 and <= 77;
+
+    public static bool IsSuitable(ClientObject item, uint selectedMaterial = 0, bool allowMultipleMaterials = true)
+    {
+        uint material = item.MaterialType ?? 0u;
+        return IsValidMaterial(material)
+            && item.Structure < 100
+            && ((item.PublicWeenieBitfield ?? 0u) & 0xFF000000u) == 0u
+            && (allowMultipleMaterials || selectedMaterial == 0u || selectedMaterial == material);
+    }
+}

--- a/tests/AcDream.App.Tests/Composition/FrameRootCompositionTests.cs
+++ b/tests/AcDream.App.Tests/Composition/FrameRootCompositionTests.cs
@@ -13,6 +13,27 @@ namespace AcDream.App.Tests.Composition;
 public sealed class FrameRootCompositionTests
 {
     [Fact]
+    public void RuntimeBindingsClearSkyActivationGateOnRollback()
+    {
+        var calls = new List<string>();
+        var gate = new RecordingSkyPesActivationGate(calls);
+        var slot = new SkyPesActivationGateSlot();
+        var bindings = new FrameRootRuntimeBindings();
+        bindings.Adopt("sky presentation effects activation", slot.BindOwned(gate));
+        var scope = new CompositionAcquisitionScope();
+        scope.Own(
+            "frame-root runtime bindings",
+            bindings,
+            static value => value.Dispose());
+
+        Assert.Throws<InvalidOperationException>(() =>
+            scope.RollbackAndThrow(new InvalidOperationException("composition failed")));
+        slot.Tick();
+
+        Assert.Empty(calls);
+    }
+
+    [Fact]
     public void RuntimeBindingsReleaseInReverseAndRetryOnlyFailedEdges()
     {
         var calls = new List<string>();
@@ -190,6 +211,12 @@ public sealed class FrameRootCompositionTests
             if (_failures-- > 0)
                 throw new InvalidOperationException("retry");
         }
+    }
+
+    private sealed class RecordingSkyPesActivationGate(List<string> calls)
+        : ISkyPesActivationGate
+    {
+        public void Tick() => calls.Add("tick");
     }
 
     private static int CallIndex(

--- a/tests/AcDream.App.Tests/Rendering/Gpu/RecordingGpuDevice.cs
+++ b/tests/AcDream.App.Tests/Rendering/Gpu/RecordingGpuDevice.cs
@@ -191,6 +191,10 @@ internal sealed class RecordingGpuDevice : IGpuDevice, IGpuPipelineFormatVariant
 
     public Func<GpuPipelineDescription, Exception?>? PipelineFailure { get; set; }
 
+    public Func<GpuTextureDescription, Exception?>? TextureFailure { get; set; }
+
+    public Func<IGpuTexture, IGpuSampler, Exception?>? TextureRegistrationFailure { get; set; }
+
     public IGpuBuffer CreateBuffer(in GpuBufferDescription description)
     {
         var buffer = new RecordingGpuBuffer(description);
@@ -204,6 +208,8 @@ internal sealed class RecordingGpuDevice : IGpuDevice, IGpuPipelineFormatVariant
 
     public IGpuTexture CreateTexture(in GpuTextureDescription description)
     {
+        if (TextureFailure?.Invoke(description) is { } failure)
+            throw failure;
         RecordingGpuTexture texture = new(
             description.Name,
             description.Kind,
@@ -308,6 +314,9 @@ internal sealed class RecordingGpuDevice : IGpuDevice, IGpuPipelineFormatVariant
     {
         ArgumentNullException.ThrowIfNull(texture);
         ArgumentNullException.ThrowIfNull(sampler);
+
+        if (TextureRegistrationFailure?.Invoke(texture, sampler) is { } failure)
+            throw failure;
 
         uint slot = _freeTextureSlots.Count > 0 ? _freeTextureSlots.Pop() : _nextTextureSlot++;
         _calls.Add(new GpuRecordedTextureRegistration(texture.Name, sampler.Description, slot));

--- a/tests/AcDream.App.Tests/Rendering/RhiCompositeTextureArrayBackendTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/RhiCompositeTextureArrayBackendTests.cs
@@ -13,6 +13,88 @@ public sealed class RhiCompositeTextureArrayBackendTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    public void UnresolvedLocationsNeverSelectATexture(bool wrapping)
+    {
+        Assert.Equal(GpuTextureSlot.Unassigned, default(BindlessTextureLocation).RepeatSlot);
+        Assert.Equal(GpuTextureSlot.Unassigned, BindlessTextureLocation.Unresolved.ResolveSlot(wrapping));
+        var unresolved = new BindlessTextureLocation(GpuTextureSlot.Unassigned, 0, new GpuTextureSlot(7));
+        Assert.Equal(GpuTextureSlot.Unassigned, unresolved.ResolveSlot(wrapping));
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(7u)]
+    public void ClampOnlyLocationsUseTheirOwnSlotForBothAddressModes(uint index)
+    {
+        var slot = new GpuTextureSlot(index);
+        var location = new BindlessTextureLocation(slot, 3);
+        Assert.Equal(GpuTextureSlot.Unassigned, location.RepeatSlot);
+        Assert.Equal(slot, location.ResolveSlot(false));
+        Assert.Equal(slot, location.ResolveSlot(true));
+        Assert.Equal(new BindlessTextureLocation(slot, 3, GpuTextureSlot.Unassigned), location);
+    }
+
+    [Fact]
+    public void AnExplicitRepeatSlotZeroRemainsUsable()
+    {
+        var location = new BindlessTextureLocation(new GpuTextureSlot(7), 3, new GpuTextureSlot(0));
+        Assert.Equal(new GpuTextureSlot(0), location.ResolveSlot(true));
+        Assert.Equal(new GpuTextureSlot(7), location.ResolveSlot(false));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void FailedCreationReleasesOnlySuccessfullyRegisteredSlots(int failureStage)
+    {
+        using var device = new RecordingGpuDevice();
+        var backend = new RhiCompositeTextureArrayBackend(device);
+        int baselineSlots = device.LiveTextureSlotCount;
+        var failure = new InvalidOperationException("Injected texture creation failure");
+        int registration = 0;
+        device.TextureFailure = _ => failureStage == 0 ? failure : null;
+        device.TextureRegistrationFailure = (_, _) => ++registration == failureStage ? failure : null;
+        device.Clear();
+
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => backend.Create(4, 4, 2)));
+
+        var registered = device.Calls.OfType<GpuRecordedTextureRegistration>().Select(call => call.Slot).ToArray();
+        var released = device.Calls.OfType<GpuRecordedTextureRelease>().Select(call => call.Slot).ToArray();
+        Assert.Equal(failureStage == 2 ? 1 : 0, registered.Length);
+        Assert.Equal(registered, released);
+        Assert.DoesNotContain(device.DefaultTextureSlot.Index, released);
+        Assert.Equal(baselineSlots, device.LiveTextureSlotCount);
+        if (failureStage == 0)
+            Assert.Empty(device.CreatedTextures);
+        else
+            Assert.True(Assert.Single(device.CreatedTextures).IsDisposed);
+    }
+
+    [Fact]
+    public void ResourceWithoutRepeatRegistrationOnlyReleasesItsOwnSlot()
+    {
+        using var device = new RecordingGpuDevice();
+        var backend = new RhiCompositeTextureArrayBackend(device);
+        var image = device.CreateTexture(new GpuTextureDescription(
+            "clamp-only", GpuTextureKind.Texture2DArray, GpuTextureFormat.Rgba8Unorm, 4, 4, 1, 1));
+        var slot = device.RegisterTexture(image, device.CreateSampler(GpuSamplerDescription.WorldClamp));
+        var resource = new CompositeTextureArrayResource
+        {
+            Name = 0, Handle = 0, Image = image, Slot = slot,
+            Width = 4, Height = 4, Capacity = 1, Bytes = 64,
+        };
+        Assert.Equal(GpuTextureSlot.Unassigned, resource.RepeatSlot);
+        device.Clear();
+        backend.MakeNonResident(resource);
+        Assert.Equal(slot.Index, Assert.Single(device.Calls.OfType<GpuRecordedTextureRelease>()).Slot);
+        Assert.Equal(1, device.LiveTextureSlotCount);
+        backend.Delete(resource);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
     public void NewAndCachedAppearanceTexturesPreserveBothAddressModes(bool palette)
     {
         using var device = new RecordingGpuDevice();

--- a/tests/AcDream.App.Tests/Rendering/RhiCompositeTextureArrayBackendTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/RhiCompositeTextureArrayBackendTests.cs
@@ -10,6 +10,31 @@ public sealed class RhiCompositeTextureArrayBackendTests
 {
     private static byte[] Rgba(int width, int height) => new byte[width * height * 4];
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NewAndCachedAppearanceTexturesPreserveBothAddressModes(bool palette)
+    {
+        using var device = new RecordingGpuDevice();
+        var backend = new RhiCompositeTextureArrayBackend(device);
+        using var cache = new CompositeTextureArrayCache(backend, ImmediateGpuResourceRetirementQueue.Instance);
+        var key = new CompositeTextureKey(
+            palette ? CompositeTextureKind.PaletteComposite : CompositeTextureKind.OriginalTextureOverride,
+            1, 2, default);
+        cache.BeginFrame();
+        Assert.True(cache.TryAddAndAcquire(1, key,
+            new AcDream.Core.Textures.DecodedTexture(Rgba(4, 4), 4, 4), out var added));
+        Assert.True(cache.TryAcquire(2, key, out var cached));
+        Assert.Equal(added, cached);
+        Assert.True(cached.ResolveSlot(true).IsAssigned);
+        Assert.NotEqual(cached.ResolveSlot(false), cached.ResolveSlot(true));
+        var registration = Assert.Single(device.Calls.OfType<GpuRecordedTextureRegistration>(),
+            r => r.Slot == cached.ResolveSlot(true).Index);
+        Assert.Equal(GpuSamplerDescription.WorldRepeat with { MipFilter = GpuMipFilter.None }, registration.Sampler);
+        Assert.Single(device.Calls.OfType<GpuRecordedTextureRegistration>(),
+            r => r.Slot == cached.ResolveSlot(false).Index);
+    }
+
     [Fact]
     public void CreateProducesASingleLevelArrayRegisteredIntoTheTable()
     {
@@ -19,6 +44,14 @@ public sealed class RhiCompositeTextureArrayBackendTests
         CompositeTextureArrayResource resource = backend.Create(32, 32, 8);
 
         Assert.True(resource.Slot.IsAssigned);
+        Assert.True(resource.RepeatSlot.IsAssigned);
+        Assert.NotEqual(resource.Slot, resource.RepeatSlot);
+        var registrations = device.Calls.OfType<GpuRecordedTextureRegistration>()
+            .Where(r => r.Slot == resource.Slot.Index || r.Slot == resource.RepeatSlot.Index).ToArray();
+        Assert.Equal(2, registrations.Length);
+        Assert.Equal(registrations[0].TextureName, registrations[1].TextureName);
+        Assert.Equal(GpuSamplerDescription.WorldClamp with { MipFilter = GpuMipFilter.None }, registrations[0].Sampler);
+        Assert.Equal(GpuSamplerDescription.WorldRepeat with { MipFilter = GpuMipFilter.None }, registrations[1].Sampler);
         Assert.Equal(32 * 32 * 4 * 8, resource.Bytes);
         // The GL identity fields are meaningless on this arm and say so.
         Assert.Equal(0u, resource.Name);
@@ -51,7 +84,7 @@ public sealed class RhiCompositeTextureArrayBackendTests
         var backend = new RhiCompositeTextureArrayBackend(device);
         int before = device.LiveTextureSlotCount;
         CompositeTextureArrayResource resource = backend.Create(32, 32, 4);
-        Assert.Equal(before + 1, device.LiveTextureSlotCount);
+        Assert.Equal(before + 2, device.LiveTextureSlotCount);
 
         backend.MakeNonResident(resource);
         Assert.Equal(before, device.LiveTextureSlotCount);

--- a/tests/AcDream.App.Tests/Rendering/SkyPesFrameControllerTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/SkyPesFrameControllerTests.cs
@@ -33,6 +33,7 @@ public sealed class SkyPesFrameControllerTests
 
         public readonly List<uint> ResolvedScriptIds = [];
         public readonly List<string> Diagnostics = [];
+        public readonly List<uint> StoppedAudioOwners = [];
         public readonly List<(uint EntityId, Vector3 Position, AnimationHook Hook)> HookCalls;
         public readonly PhysicsScriptRunner Runner;
         public readonly SkyPesFrameController Controller;
@@ -87,7 +88,8 @@ public sealed class SkyPesFrameControllerTests
                 sink,
                 poses,
                 effects: null,
-                Diagnostics.Add);
+                Diagnostics.Add,
+                StoppedAudioOwners.Add);
         }
     }
 
@@ -242,5 +244,35 @@ public sealed class SkyPesFrameControllerTests
         Assert.Same(sound, call.Hook);
         Assert.Equal(currentCamera, call.Position);
         Assert.Single(h.ResolvedScriptIds);
+    }
+
+    [Fact]
+    public void EnclosedFrameStopsSkyHooksAndAudioWhilePreservingOtherOwners()
+    {
+        var sound = new SoundTweakedHook
+        {
+            SoundId = 0x0A00038Bu,
+            Volume = 0.1f,
+            Priority = 1f,
+        };
+        var h = new Harness(sound, hookTime: 1.0);
+        const uint otherOwner = 0x50000001u;
+
+        h.Controller.Update(0.3f, Group(Carrier()), Vector3.Zero);
+        Assert.True(h.Runner.PlayDirect(otherOwner, AuroraScript));
+
+        h.Controller.Update(0.4f, Group(Carrier()), Vector3.Zero, skyActive: false);
+        h.Runner.Tick(1.0);
+
+        var otherCall = Assert.Single(h.HookCalls);
+        Assert.Equal(otherOwner, otherCall.EntityId);
+        Assert.Equal([0xF0000000u], h.StoppedAudioOwners);
+        Assert.Equal(0, h.Runner.ActiveScriptCount);
+
+        h.Controller.Update(0.5f, Group(Carrier()), Vector3.One, skyActive: true);
+        h.Runner.Tick(2.0);
+
+        Assert.Equal(2, h.HookCalls.Count);
+        Assert.Equal(0xF0000000u, h.HookCalls[1].EntityId);
     }
 }

--- a/tests/AcDream.App.Tests/Rendering/Walk/RetailFrameWalkTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/Walk/RetailFrameWalkTests.cs
@@ -84,6 +84,7 @@ public sealed class RetailFrameWalkTests
 
         public Vector3 ViewpointInBuilding(WalkBuilding building) => Vector3.Zero;
         public virtual float ViewerDistanceTo(WalkBuilding building) => 0f;
+        public bool BuildingDegradesDisabled { get; set; }
         public IWalkFrameContext CellContext => this;
         public WalkPlane CyPlane { get; set; } = new(new Vector3(0, 0, 1), 0f);
         public void SetActiveView(WalkPortalView views, int index) { }
@@ -299,6 +300,74 @@ public sealed class RetailFrameWalkTests
     private sealed class DistanceContext(float distance) : TestContext
     {
         public override float ViewerDistanceTo(WalkBuilding building) => distance;
+    }
+
+    [Fact]
+    public void OverheadBuildingSelectionSurvivesTheFinalEmptyLevelAndRestoresDistanceSelection()
+    {
+        var building = new WalkBuilding
+        {
+            GfxObjId = 0x01000001u,
+            DegradeLevels =
+            [
+                new(0x01000001u, 1u, 24f, 48f, 96f, null),
+                new(0x01000002u, 1u, 192f, 392f, 392f, null),
+                new(0u, 1u, float.MaxValue, float.MaxValue, float.MaxValue, null),
+            ],
+        };
+        var walk = new RetailFrameWalk();
+        var context = new DistanceContext(450f);
+        var normal = new Recorder();
+        walk.DrawBuilding(building, new WalkPortalView(), context, normal);
+        Assert.Empty(normal.ShellSelections);
+
+        context.BuildingDegradesDisabled = true;
+        var overhead = new Recorder();
+        walk.DrawBuilding(building, new WalkPortalView(), context, overhead);
+        Assert.Equal(0x01000001u, Assert.Single(overhead.ShellSelections).GfxObjId);
+
+        context.BuildingDegradesDisabled = false;
+        var restored = new Recorder();
+        walk.DrawBuilding(building, new WalkPortalView(), context, restored);
+        Assert.Empty(restored.ShellSelections);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void CoarseTerrainDrawsAllBuildingShellsWithinObjectRangeAndUpdatesOnRecenter(int ring)
+    {
+        const uint viewerCell = 0xA9B40001u;
+        uint landblock = 0xA9000000u | ((uint)(0xB4 + ring) << 16);
+        var entries = new[] { 1u, 2u, 64u }.Select((cell, index) =>
+            new WalkBuildingFactory.Entry(
+                new WalkBuilding { PositionCellId = landblock | cell, GfxObjId = 0x01000001u + (uint)index },
+                Matrix4x4.Identity, Matrix4x4.Identity)).ToArray();
+        var assembler = new WalkLandscapeAssembler();
+        assembler.PublishLandblock(landblock, 10f, 0f, entries);
+        assembler.SetViewer(viewerCell, Vector3.Zero);
+        var walk = new RetailFrameWalk { ObjectRingLimit = ring };
+
+        AssertShells(3);
+        walk.ObjectRingLimit = ring - 1;
+        AssertShells(0);
+        walk.ObjectRingLimit = ring;
+
+        assembler.SetViewer(landblock | 1u, Vector3.Zero);
+        AssertShells(3);
+        assembler.SetViewer(viewerCell, Vector3.Zero);
+        AssertShells(3);
+        assembler.ClearBuildings(landblock);
+        AssertShells(0);
+
+        void AssertShells(int count)
+        {
+            var recorder = new Recorder();
+            walk.DrawLandscape(assembler.Landscape, new WalkPortalView(), new TestContext(), recorder);
+            Assert.Equal(count, recorder.ShellSelections.Count);
+            Assert.Equal(count, recorder.ShellSelections.Select(s => s.GfxObjId).Distinct().Count());
+        }
     }
 
 

--- a/tests/AcDream.App.Tests/Rendering/Walk/WalkLandscapeAssemblerTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/Walk/WalkLandscapeAssemblerTests.cs
@@ -50,7 +50,7 @@ public sealed class WalkLandscapeAssemblerTests
     }
 
     [Fact]
-    public void RingPyramid_FarBlockDegradesSideCellCountAndNeverAttachesBuildings()
+    public void RingPyramid_FarBlockKeepsBuildingsInCoarseCellBuckets()
     {
         var assembler = new WalkLandscapeAssembler();
         var building = new WalkBuildingFactory.Entry(
@@ -69,6 +69,7 @@ public sealed class WalkLandscapeAssemblerTests
         Assert.Contains(center.CellBuildings, b => b is not null);
         Assert.Equal(2, far.SideCellCount);
         Assert.All(far.CellBuildings, Assert.Null);
+        Assert.Same(building.Building, Assert.Single(far.CoarseCellBuildings.SelectMany(b => b)));
     }
 
     [Fact]

--- a/tests/AcDream.App.Tests/Rendering/Walk/WalkProductionFrameContextTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/Walk/WalkProductionFrameContextTests.cs
@@ -11,6 +11,17 @@ public sealed class WalkProductionFrameContextTests
         * Matrix4x4.CreatePerspectiveFieldOfView(MathF.PI / 3f, 4f / 3f, 0.1f, 1000f);
 
     [Fact]
+    public void FrameResetRestoresBuildingDetailPolicy()
+    {
+        var ctx = new WalkProductionFrameContext(
+            new CellVisibility(), new WalkBuildingRegistry(), Vector3.Zero, Vector3.UnitY,
+            SimpleViewProjection(), 1024f, 768f, buildingDegradesDisabled: true);
+        Assert.True(((IRetailFrameWalkContext)ctx).BuildingDegradesDisabled);
+        ctx.Reset(Vector3.Zero, Vector3.UnitY, SimpleViewProjection(), 1024f, 768f);
+        Assert.False(((IRetailFrameWalkContext)ctx).BuildingDegradesDisabled);
+    }
+
+    [Fact]
     public void GetVisible_ResolvesThroughTheCommittedCellVisibilityRegistry()
     {
         var cellVisibility = new CellVisibility();

--- a/tests/AcDream.App.Tests/Rendering/WorldRenderFrameBuilderTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/WorldRenderFrameBuilderTests.cs
@@ -1,18 +1,26 @@
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using AcDream.App.Composition;
 using AcDream.App.Input;
 using AcDream.App.Rendering;
+using AcDream.App.Rendering.Gpu;
 using AcDream.App.Rendering.Wb;
 using AcDream.App.Rendering.Vfx;
 using AcDream.App.Streaming;
+using AcDream.App.Tests.Rendering.Gpu;
 using AcDream.App.Tests.Architecture;
 using AcDream.App.World;
 using AcDream.Core.Lighting;
 using AcDream.Core.Physics;
 using AcDream.Core.Rendering;
+using AcDream.Core.Vfx;
 using AcDream.Core.World;
 using AcDream.Core.World.Cells;
+using DatPhysicsScript = DatReaderWriter.DBObjs.PhysicsScript;
+using DatAnimationHook = DatReaderWriter.Types.AnimationHook;
+using DatPhysicsScriptData = DatReaderWriter.Types.PhysicsScriptData;
+using DatSoundTweakedHook = DatReaderWriter.Types.SoundTweakedHook;
 
 namespace AcDream.App.Tests.Rendering;
 
@@ -214,6 +222,7 @@ public sealed class WorldRenderFrameBuilderTests
             Assert.False(result.PlayerSeenOutside);
             Assert.True(result.RootSeenOutside);
             Assert.True(result.RenderSky);
+            Assert.False(result.SkyEffectsActive);
             Assert.False(result.CameraInsideEnclosedCell);
             Assert.True(result.PlayerOrCameraInsideEnclosedCell);
             Assert.True(result.IsAtmosphericallyOutdoor);
@@ -249,9 +258,127 @@ public sealed class WorldRenderFrameBuilderTests
         Assert.False(result.PlayerInsideCell);
         Assert.False(result.CameraInsideCell);
         Assert.True(result.RenderSky);
+        Assert.True(result.SkyEffectsActive);
         Assert.False(result.CameraInsideEnclosedCell);
         Assert.False(result.PlayerOrCameraInsideEnclosedCell);
         Assert.True(result.IsAtmosphericallyOutdoor);
+    }
+
+    [Fact]
+    public void Map_mode_disables_distance_fog_only_for_the_active_retail_chase_camera()
+    {
+        var atmosphere = new AtmosphereSnapshot(
+            WeatherKind.Storm,
+            Intensity: 0.8f,
+            FogColor: new Vector3(0.1f, 0.2f, 0.3f),
+            FogStart: 30f,
+            FogEnd: 180f,
+            FogMode: FogMode.Linear,
+            LightningFlash: 0.6f,
+            Override: EnvironOverride.BlackFog);
+        var controller = new CameraController(new OrbitCamera(), new FlyCamera());
+        var legacy = new ChaseCamera();
+        var retail = new RetailChaseCamera();
+        controller.EnterChaseMode(legacy, retail);
+        retail.ToggleRetailMapModeView();
+        bool savedRetailCamera = CameraDiagnostics.UseRetailChaseCamera;
+
+        try
+        {
+            CameraDiagnostics.UseRetailChaseCamera = true;
+            var viewPlane = new TeleportViewPlaneController();
+            viewPlane.Begin(controller.Active.Projection);
+            var source = new RuntimeWorldFrameCameraSource(controller, viewPlane.ApplyTo);
+            WorldCameraFrame overheadFrame = source.Resolve();
+            Assert.True(WorldCameraViewPolicy.IsOverheadView(controller.Active));
+            Assert.False(WorldCameraViewPolicy.IsOverheadView(overheadFrame.Camera));
+            Assert.True(overheadFrame.IsOverheadView);
+
+            using var device = new RecordingGpuDevice();
+            using IGpuFrame gpuFrame = device.BeginFrame();
+            var sections = new WorldFrameSections();
+            using var lightingUbo = new SceneLightingUboBinding(
+                new FixedGpuFrameSource(gpuFrame),
+                sections);
+            lightingUbo.BeginFrame(gpuFrame.SlotIndex);
+            var environment = new RuntimeWorldFrameEnvironmentPreparation(
+                RuntimeOptions.Parse("test-dat", _ => null),
+                new WorldTimeService(SkyStateProvider.Default()),
+                new LightManager(),
+                dispatcher: null,
+                environmentCells: null,
+                lightingUbo,
+                new WorldRenderRangeState(4, 12),
+                skyPes: null);
+            WorldRootFrame roots = default;
+            var foundation = new RenderFrameFoundation(
+                PortalViewportVisible: false,
+                Sky: default,
+                Atmosphere: atmosphere);
+
+            environment.Prepare(in overheadFrame, in roots, in foundation, activeDayGroup: null);
+            SceneLightingUbo overheadUbo = ReadSceneLighting(sections);
+            Assert.Equal((float)FogMode.Off, overheadUbo.FogParams.W);
+            Assert.Equal(atmosphere.FogStart, overheadUbo.FogParams.X);
+            Assert.Equal(atmosphere.FogEnd, overheadUbo.FogParams.Y);
+            Assert.Equal(atmosphere.LightningFlash, overheadUbo.FogParams.Z);
+
+            CameraDiagnostics.UseRetailChaseCamera = false;
+            Assert.False(WorldCameraViewPolicy.IsOverheadView(controller.Active));
+            Assert.False(source.Resolve().IsOverheadView);
+
+            controller.ToggleFly();
+            Assert.False(source.Resolve().IsOverheadView);
+            controller.ToggleFly();
+            Assert.False(source.Resolve().IsOverheadView);
+
+            controller.EnterChaseMode(legacy, retail);
+
+            retail.ToggleRetailMapModeView();
+            CameraDiagnostics.UseRetailChaseCamera = true;
+            WorldCameraFrame restoredFrame = source.Resolve();
+            Assert.False(restoredFrame.IsOverheadView);
+            AtmosphereSnapshot newWeather = atmosphere with
+            {
+                FogMode = FogMode.Exp2,
+                FogStart = 240f,
+                FogEnd = 720f,
+            };
+            RenderFrameFoundation afterMapExit = foundation with { Atmosphere = newWeather };
+            environment.Prepare(in restoredFrame, in roots, in afterMapExit, activeDayGroup: null);
+            SceneLightingUbo restoredUbo = ReadSceneLighting(sections);
+            Assert.Equal((float)newWeather.FogMode, restoredUbo.FogParams.W);
+            Assert.Equal(newWeather.FogStart, restoredUbo.FogParams.X);
+            Assert.Equal(newWeather.FogEnd, restoredUbo.FogParams.Y);
+
+            AtmosphereSnapshot userDisabled = newWeather with { FogMode = FogMode.Off };
+            RenderFrameFoundation disabledByUser = foundation with { Atmosphere = userDisabled };
+            environment.Prepare(in restoredFrame, in roots, in disabledByUser, activeDayGroup: null);
+            Assert.Equal((float)FogMode.Off, ReadSceneLighting(sections).FogParams.W);
+
+            CameraDiagnostics.UseRetailChaseCamera = false;
+            legacy.ToggleRetailMapModeView();
+            WorldCameraFrame legacyMapFrame = source.Resolve();
+            Assert.True(legacyMapFrame.IsOverheadView);
+            environment.Prepare(in legacyMapFrame, in roots, in afterMapExit, activeDayGroup: null);
+            Assert.Equal((float)FogMode.Off, ReadSceneLighting(sections).FogParams.W);
+
+            legacy.ToggleRetailMapModeView();
+            WorldCameraFrame legacyRestoredFrame = source.Resolve();
+            Assert.False(legacyRestoredFrame.IsOverheadView);
+            environment.Prepare(in legacyRestoredFrame, in roots, in afterMapExit, activeDayGroup: null);
+            Assert.Equal((float)newWeather.FogMode, ReadSceneLighting(sections).FogParams.W);
+
+            CameraDiagnostics.UseRetailChaseCamera = true;
+            retail.ToggleRetailLookDownView();
+            Assert.False(source.Resolve().IsOverheadView);
+            retail.SetRetailFirstPersonView();
+            Assert.False(source.Resolve().IsOverheadView);
+        }
+        finally
+        {
+            CameraDiagnostics.UseRetailChaseCamera = savedRetailCamera;
+        }
     }
 
     [Fact]
@@ -296,6 +423,103 @@ public sealed class WorldRenderFrameBuilderTests
 
         Assert.Contains(visibleLight, lighting.PointSnapshot);
         Assert.Contains(hiddenLight, lighting.PointSnapshot);
+    }
+
+    [Fact]
+    public void Runtime_environment_stops_sky_hooks_before_an_enclosed_frame_can_dispatch_them()
+    {
+        const uint otherOwner = 0x50000001u;
+        var calls = new List<(uint EntityId, DatAnimationHook Hook)>();
+        var router = new AnimationHookRouter();
+        router.Register(new RecordingHookSink(calls));
+        var sound = new DatSoundTweakedHook
+        {
+            SoundId = 0x0A00038Bu,
+            Volume = 0.1f,
+            Priority = 1f,
+        };
+        var script = new DatPhysicsScript();
+        script.ScriptData.Add(new DatPhysicsScriptData
+        {
+            StartTime = 1.0,
+            Hook = sound,
+        });
+        var runner = new PhysicsScriptRunner(_ => script, router);
+        var poses = new EntityEffectPoseRegistry();
+        var particles = new ParticleHookSink(
+            new ParticleSystem(new EmitterDescRegistry()),
+            poses);
+        var stoppedAudioOwners = new List<uint>();
+        var skyPes = new SkyPesFrameController(
+            runner,
+            particles,
+            poses,
+            effects: null,
+            diagnostic: null,
+            stopAudio: stoppedAudioOwners.Add);
+        var environment = new RuntimeWorldFrameEnvironmentPreparation(
+            RuntimeOptions.Parse("test-dat", _ => null),
+            new WorldTimeService(SkyStateProvider.Default()),
+            new LightManager(),
+            dispatcher: null,
+            environmentCells: null,
+            lightingUbo: null,
+            new WorldRenderRangeState(4, 12),
+            skyPes);
+        WorldCameraFrame camera = CameraFrame(new FlyCamera());
+        RenderFrameFoundation foundation = default;
+        var sky = new DayGroupData
+        {
+            Name = "Test",
+            SkyObjects =
+            [
+                new SkyObjectData
+                {
+                    GfxObjId = 0x02000714u,
+                    DefaultScriptId = 0x330007DBu,
+                    PesObjectId = 0x330007DBu,
+                },
+            ],
+        };
+        WorldRootFrame outdoor = default;
+        var enclosed = new WorldRootFrame(
+            PlayerRoot: null,
+            PlayerSeenOutside: false,
+            ViewerCellId: 0x01010100u,
+            ViewerEyePosition: Vector3.Zero,
+            PlayerViewPosition: Vector3.Zero,
+            ViewerRoot: new LoadedCell { CellId = 0x01010100u, SeenOutside = true },
+            CameraInsideCell: true,
+            RootSeenOutside: true,
+            PlayerInsideCell: true,
+            PlayerLandblockId: null,
+            RenderCenterLandblockX: 0,
+            RenderCenterLandblockY: 0,
+            PlayerCellId: 0x01010100u,
+            PlayerIndoorGate: true);
+
+        Assert.True(enclosed.RenderSky);
+        Assert.False(enclosed.SkyEffectsActive);
+
+        environment.Prepare(in camera, in outdoor, in foundation, sky);
+        Assert.True(runner.PlayDirect(otherOwner, 0x330007DBu));
+
+        var updateGate = new RuntimeSkyPesActivationGate(
+            skyPes,
+            new RecordingCamera([], camera),
+            new RecordingRoots([], enclosed));
+        updateGate.Tick();
+        runner.Tick(1.0);
+
+        var otherCall = Assert.Single(calls);
+        Assert.Equal(otherOwner, otherCall.EntityId);
+        Assert.Equal([0xF0000000u], stoppedAudioOwners);
+
+        environment.Prepare(in camera, in outdoor, in foundation, sky);
+        runner.Tick(2.0);
+
+        Assert.Equal(2, calls.Count);
+        Assert.Equal(0xF0000000u, calls[1].EntityId);
     }
 
     [Fact]
@@ -494,6 +718,33 @@ public sealed class WorldRenderFrameBuilderTests
             calls.Add("camera");
             return result;
         }
+    }
+
+    private sealed class RecordingHookSink(
+        List<(uint EntityId, DatAnimationHook Hook)> calls) : IAnimationHookSink
+    {
+        public void OnHook(
+            uint entityId,
+            Vector3 entityWorldPosition,
+            DatAnimationHook hook)
+        {
+            _ = entityWorldPosition;
+            calls.Add((entityId, hook));
+        }
+    }
+
+    private static SceneLightingUbo ReadSceneLighting(WorldFrameSections sections)
+    {
+        GpuBufferSection section = sections.SceneLighting;
+        Assert.True(section.IsValid);
+        Span<byte> bytes = stackalloc byte[SceneLightingUbo.SizeInBytes];
+        section.Buffer!.Read(section.OffsetBytes, bytes);
+        return MemoryMarshal.Read<SceneLightingUbo>(bytes);
+    }
+
+    private sealed class FixedGpuFrameSource(IGpuFrame frame) : ICurrentGpuFrameSource
+    {
+        public IGpuFrame? CurrentFrame => frame;
     }
 
     private sealed class RecordingVisibility(List<string> calls)

--- a/tests/AcDream.App.Tests/Rendering/WorldSceneRendererTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/WorldSceneRendererTests.cs
@@ -289,6 +289,21 @@ public sealed class WorldSceneRendererTests
     }
 
     [Fact]
+    public void PViewWorld_OverheadDetailOverrideIsReplacedOnEveryFrame()
+    {
+        var root = new LoadedCell { CellId = 0x01010001u };
+        var rig = new Rig(false, false, root);
+        WorldRenderFrame normal = rig.Frames.Frame;
+        rig.Frames.Frame = normal with { Camera = normal.Camera with { IsOverheadView = true } };
+        rig.Renderer.Render(default);
+        Assert.True(rig.PView.LastInput!.BuildingDegradesDisabled);
+
+        rig.Frames.Frame = normal;
+        rig.Renderer.Render(default);
+        Assert.False(rig.PView.LastInput!.BuildingDegradesDisabled);
+    }
+
+    [Fact]
     public void OutdoorPView_SkipsPostWorldParticleReplayAndFlatWeather()
     {
         var root = new LoadedCell
@@ -856,6 +871,7 @@ public sealed class WorldSceneRendererTests
     private sealed class FrameBuilder(List<string> calls, WorldRenderFrame frame) :
         IWorldRenderFrameBuilder
     {
+        public WorldRenderFrame Frame { get; set; } = frame;
         public RenderFrameFoundation Foundation { get; private set; }
 
         public bool WaitingForLogin { get; private set; }
@@ -871,7 +887,7 @@ public sealed class WorldSceneRendererTests
             Foundation = foundation;
             WaitingForLogin = waitingForLogin;
             ActiveDayGroup = activeDayGroup;
-            return frame;
+            return Frame;
         }
 
     }

--- a/tests/AcDream.App.Tests/UI/ItemInteractionControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/ItemInteractionControllerTests.cs
@@ -635,6 +635,22 @@ public sealed class ItemInteractionControllerTests
     }
 
     [Fact]
+    public void PrimaryUseOfOwnedSalvageTool_requestsSalvagePanel()
+    {
+        var h = new Harness();
+        const uint tool = 0x50000A31u;
+        var actions = new List<ItemPolicyAction>();
+        h.Controller.PolicyActionRequested += actions.Add;
+        h.AddContained(tool, item => item.Type = ItemType.TinkeringTool);
+
+        Assert.True(h.Controller.ActivateItem(tool));
+
+        Assert.Equal(
+            [new ItemPolicyAction(ItemPolicyActionKind.OpenSalvage, tool)],
+            actions);
+    }
+
+    [Fact]
     public void ZeroValuedUseabilityGem_sendsUseLikeBlackmoorsFavor()
     {
         var h = new Harness();
@@ -2230,6 +2246,47 @@ public sealed class ItemInteractionControllerTests
         h.Objects.Get(source)!.Structure = 100;
         Assert.False(h.Controller.TrySalvageItemsForAutomation(tool, [source]));
         Assert.Single(h.Salvages);
+    }
+
+    [Theory]
+    [InlineData(3u)]
+    [InlineData(9u)]
+    [InlineData(56u)]
+    [InlineData(65u)]
+    [InlineData(72u)]
+    public void TrySalvageItems_rejectsInvalidMaterialGroup(uint materialType)
+    {
+        var h = new Harness();
+        const uint tool = 0x50000A42u;
+        const uint source = 0x50000A43u;
+        h.AddContained(tool, item => item.Type = ItemType.TinkeringTool);
+        h.AddContained(source, item =>
+        {
+            item.MaterialType = materialType;
+            item.Structure = 50;
+        });
+
+        Assert.False(h.Controller.TrySalvageItems(tool, [source]));
+        Assert.Empty(h.Salvages);
+    }
+
+    [Fact]
+    public void TrySalvageItems_sendsOwnedSuitableItem()
+    {
+        var h = new Harness();
+        const uint tool = 0x50000A44u;
+        const uint source = 0x50000A45u;
+        h.AddContained(tool, item => item.Type = ItemType.TinkeringTool);
+        h.AddContained(source, item =>
+        {
+            item.MaterialType = 12u;
+            item.Structure = 50;
+        });
+
+        Assert.True(h.Controller.TrySalvageItems(tool, [source]));
+        Assert.Single(h.Salvages);
+        Assert.Equal(tool, h.Salvages[0].ToolGuid);
+        Assert.Equal(new[] { source }, h.Salvages[0].ItemGuids);
     }
 
     [Fact]

--- a/tests/AcDream.App.Tests/UI/Layout/AppraisalUiControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/AppraisalUiControllerTests.cs
@@ -8,6 +8,7 @@ using AcDream.Core.Items;
 using AcDream.Core.Net.Messages;
 using AcDream.Core.Selection;
 using AcDream.Core.Spells;
+using AcDream.UI.Abstractions.Input;
 
 namespace AcDream.App.Tests.UI.Layout;
 
@@ -15,6 +16,47 @@ public sealed class AppraisalUiControllerTests
 {
     private const uint ObjectId = 0x50000001u;
     private static (uint, int, int) NoTexture(uint _) => (0u, 0, 0);
+
+    [Fact]
+    public void InspectKeyClosesVisibleWindowAndAllowsNextInspectToOpenIt()
+    {
+        ImportedLayout layout = FixtureLoader.LoadExamination();
+        var objects = new ClientObjectTable();
+        objects.AddOrUpdate(new ClientObject
+        {
+            ObjectId = ObjectId,
+            Name = "Chainmail Basinet",
+            Type = ItemType.Clothing,
+        });
+        var sent = new List<uint>();
+        using var interaction = NewInteraction(objects, sent);
+        int shown = 0;
+        int closed = 0;
+        using AppraisalUiController controller = Bind(
+            layout, objects, interaction, new CombatState(), [], [],
+            () => shown++, () => closed++)!;
+
+        Assert.False(controller.HandleInputAction(InputAction.SelectionExamine));
+        Assert.True(interaction.ExamineSelectedOrEnterMode(ObjectId));
+        Assert.True(controller.Apply(Parsed(new PropertyBundle())));
+        controller.OnShown();
+
+        Assert.False(controller.HandleInputAction(InputAction.SelectRight));
+        Assert.True(controller.HandleInputAction(InputAction.SelectionExamine));
+        Assert.Equal(1, closed);
+        Assert.Single(sent);
+        Assert.Equal(0, interaction.BusyCount);
+        controller.OnHidden();
+
+        Assert.False(controller.HandleInputAction(InputAction.SelectionExamine));
+        Assert.True(interaction.ExamineSelectedOrEnterMode(ObjectId));
+        Assert.True(controller.Apply(Parsed(new PropertyBundle())));
+        controller.OnShown();
+        Assert.Equal(2, shown);
+        Assert.Equal(2, sent.Count);
+        Assert.True(controller.HandleInputAction(InputAction.SelectionExamine));
+        Assert.Equal(2, closed);
+    }
 
     [Fact]
     public void ItemResponse_UsesAuthoredItemSubviewTitleAndScrollbars()

--- a/tests/AcDream.App.Tests/UI/Layout/InventoryControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/InventoryControllerTests.cs
@@ -654,6 +654,30 @@ public class InventoryControllerTests
         Assert.Equal(-1f, grid.GetItem(0)!.CapacityFill);
     }
 
+    [Fact]
+    public void SalvageBag_structureIndicator_tracksPartialFullAndDepletedUpdates()
+    {
+        const uint salvageBag = 0xAu;
+        var (layout, grid, _, _, _, _, _, _) = BuildLayout();
+        var objects = new ClientObjectTable();
+        SeedContained(objects, salvageBag, Player, slot: 0);
+        ClientObject bag = objects.Get(salvageBag)!;
+        bag.Structure = 30;
+        bag.MaxStructure = 100;
+        objects.AddOrUpdate(bag);
+        using var controller = Bind(layout, objects);
+
+        Assert.Equal(0.3f, grid.GetItem(0)!.StructureFill);
+
+        bag.Structure = 100;
+        objects.AddOrUpdate(bag);
+        Assert.Equal(-1f, grid.GetItem(0)!.StructureFill);
+
+        bag.Structure = 0;
+        objects.AddOrUpdate(bag);
+        Assert.Equal(0f, grid.GetItem(0)!.StructureFill);
+    }
+
     private static ItemDragPayload Payload(uint obj) => new(obj, ItemDragSource.Inventory, 0, new UiItemSlot());
 
     private static WeenieData WorldReplacement(uint guid) => new(

--- a/tests/AcDream.App.Tests/UI/Layout/SalvageUiControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/SalvageUiControllerTests.cs
@@ -1,0 +1,216 @@
+using AcDream.App.UI;
+using AcDream.App.UI.Layout;
+using AcDream.Core.Items;
+
+namespace AcDream.App.Tests.UI.Layout;
+
+public sealed class SalvageUiControllerTests
+{
+    private const uint Player = 100;
+    private const uint Tool = 101;
+    private sealed class Element : UiElement { }
+
+    private sealed class Harness : IDisposable
+    {
+        public ClientObjectTable Objects { get; } = new();
+        public UiItemList List { get; } = new() { Width = 320, Height = 32 };
+        public UiButton Button { get; } = new(new ElementInfo { Id = SalvageUiController.SalvageButtonId, Type = 1 }, _ => (0u, 0, 0));
+        public SalvageUiController Controller { get; }
+        public bool Visible;
+        public bool Multiple = true;
+        public bool SendSucceeds = true;
+        public List<(uint Tool, uint[] Items)> Sends { get; } = [];
+        public List<string> Errors { get; } = [];
+
+        public Harness()
+        {
+            var root = new Element();
+            root.AddChild(List);
+            root.AddChild(Button);
+            var layout = new ImportedLayout(root, new()
+            {
+                [SalvageUiController.ItemListId] = List,
+                [SalvageUiController.SalvageButtonId] = Button,
+            });
+            Objects.AddOrUpdate(new ClientObject { ObjectId = Player, Type = ItemType.Creature });
+            Objects.AddOrUpdate(new ClientObject { ObjectId = Tool, Type = ItemType.TinkeringTool });
+            Objects.MoveItem(Tool, Player, 0);
+            Controller = SalvageUiController.Bind(layout, new(
+                Objects, id => Objects.IsOwnedByObject(id, Player),
+                (tool, items) => { Sends.Add((tool, items.ToArray())); return SendSucceeds; },
+                () => Multiple, (_, icon, _, _, _) => icon,
+                visible => Visible = visible, Errors.Add))!;
+            Controller.Open(Tool);
+        }
+
+        public ClientObject Item(uint id, uint material = 60, int structure = 0, uint container = Player)
+        {
+            var item = new ClientObject { ObjectId = id, MaterialType = material, Structure = structure, IconId = 123 };
+            Objects.AddOrUpdate(item);
+            Objects.MoveItem(id, container, 0);
+            return item;
+        }
+
+        public void Dispose() => Controller.Dispose();
+    }
+
+    [Fact]
+    public void Eligible_drop_marks_item_and_submit_sends_once_without_removing_inventory()
+    {
+        using var h = new Harness();
+        var item = h.Item(1);
+        var cell = new UiItemSlot();
+        var payload = new ItemDragPayload(1, ItemDragSource.Inventory, 0, cell);
+        Assert.True(h.Visible);
+        Assert.False(h.Button.Enabled);
+        Assert.Equal(ItemDragAcceptance.Accept, h.Controller.OnDragOver(h.List, cell, payload));
+        h.Controller.HandleDropRelease(h.List, cell, payload);
+        Assert.Equal(1, h.Controller.ItemCount);
+        Assert.Equal(1, item.TradeState);
+        Assert.True(h.Button.Enabled);
+        Assert.Equal(ItemDragAcceptance.Reject, h.Controller.OnDragOver(h.List, cell, payload));
+        Assert.True(h.Controller.Salvage());
+        Assert.False(h.Controller.Salvage());
+        var sent = Assert.Single(h.Sends);
+        Assert.Equal(Tool, sent.Tool);
+        Assert.Equal(new uint[] { 1 }, sent.Items);
+        Assert.Same(item, h.Objects.Get(1));
+        Assert.Equal(0, item.TradeState);
+        Assert.Equal(0, h.Controller.ItemCount);
+        Assert.False(h.Button.Enabled);
+        Assert.True(h.Visible);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(3, 0)]
+    [InlineData(9, 0)]
+    [InlineData(56, 0)]
+    [InlineData(65, 0)]
+    [InlineData(72, 0)]
+    [InlineData(60, 100)]
+    public void Invalid_materials_and_full_bags_are_rejected(uint material, int structure)
+    {
+        using var h = new Harness();
+        h.Item(1, material, structure);
+        Assert.False(h.Controller.CanAdd(1));
+        Assert.False(h.Controller.AddItem(1));
+        Assert.Empty(h.Sends);
+    }
+
+    [Fact]
+    public void Container_drop_filters_contents_and_obeys_material_option()
+    {
+        using var h = new Harness { Multiple = false };
+        h.Objects.AddOrUpdate(new ClientObject { ObjectId = 10, Type = ItemType.Container, ItemsCapacity = 24 });
+        h.Objects.MoveItem(10, Player, 0);
+        var first = h.Item(1, 60, container: 10);
+        var other = h.Item(2, 61, container: 10);
+        var full = h.Item(3, 60, 100, 10);
+        Assert.True(h.Controller.AddItem(10));
+        Assert.Equal(1, h.Controller.ItemCount);
+        Assert.Equal(1, first.TradeState);
+        Assert.Equal(0, other.TradeState);
+        Assert.Equal(0, full.TradeState);
+        h.Multiple = true;
+        Assert.True(h.Controller.AddItem(2));
+        Assert.Equal(2, h.Controller.ItemCount);
+    }
+
+    [Fact]
+    public void Dragging_out_and_right_click_remove_staging()
+    {
+        using var h = new Harness();
+        var item = h.Item(1);
+        h.Controller.AddItem(1);
+        var cell = new UiItemSlot();
+        h.Controller.OnDragLift(h.List, cell, new(1, ItemDragSource.Inventory, 0, cell));
+        Assert.Equal(0, item.TradeState);
+        Assert.Equal(0, h.Controller.ItemCount);
+        h.Controller.AddItem(1);
+        h.List.ExamineItemRequested!(1);
+        Assert.Equal(0, item.TradeState);
+        Assert.False(h.Button.Enabled);
+    }
+
+    [Fact]
+    public void Staged_partial_bag_keeps_its_structure_meter()
+    {
+        using var h = new Harness();
+        var item = h.Item(1, structure: 25);
+        item.MaxStructure = 100;
+        h.Controller.AddItem(1);
+        Assert.Equal(0.25f, h.List.GetItem(0)!.StructureFill);
+        Assert.True(h.List.GetItem(0)!.ShowTradeOverlay);
+    }
+
+    [Fact]
+    public void Submit_orders_items_from_last_staged_to_first()
+    {
+        using var h = new Harness();
+        h.Item(1);
+        h.Item(2);
+        h.Controller.AddItem(1);
+        h.Controller.AddItem(2);
+        Assert.True(h.Controller.Salvage());
+        Assert.Equal(new uint[] { 2, 1 }, Assert.Single(h.Sends).Items);
+    }
+
+    [Fact]
+    public void Failed_send_preserves_staged_items_for_retry()
+    {
+        using var h = new Harness { SendSucceeds = false };
+        var item = h.Item(1);
+        h.Controller.AddItem(1);
+        Assert.False(h.Controller.Salvage());
+        Assert.Equal(1, h.Controller.ItemCount);
+        Assert.Equal(1, item.TradeState);
+        Assert.Single(h.Errors);
+        h.SendSucceeds = true;
+        Assert.True(h.Controller.Salvage());
+        Assert.Equal(0, item.TradeState);
+    }
+
+    [Fact]
+    public void Item_move_removes_staging_and_tool_removal_closes_window()
+    {
+        using var h = new Harness();
+        var item = h.Item(1);
+        h.Controller.AddItem(1);
+        h.Objects.MoveItem(1, 999, 0);
+        Assert.Equal(0, item.TradeState);
+        Assert.Equal(0, h.Controller.ItemCount);
+        h.Objects.Remove(Tool);
+        Assert.False(h.Visible);
+        Assert.Equal(0u, h.Controller.ToolId);
+    }
+
+    [Fact]
+    public void Moving_container_out_of_inventory_clears_its_staged_children()
+    {
+        using var h = new Harness();
+        h.Objects.AddOrUpdate(new ClientObject { ObjectId = 10, Type = ItemType.Container, ItemsCapacity = 24 });
+        h.Objects.MoveItem(10, Player, 0);
+        var item = h.Item(1, container: 10);
+        h.Controller.AddItem(1);
+        h.Objects.MoveItem(10, 999, 0);
+        Assert.Equal(0, item.TradeState);
+        Assert.Equal(0, h.Controller.ItemCount);
+        Assert.False(h.Button.Enabled);
+    }
+
+    [Fact]
+    public void Hiding_and_reopening_clears_staging()
+    {
+        using var h = new Harness();
+        var item = h.Item(1);
+        h.Controller.AddItem(1);
+        h.Controller.OnHidden();
+        Assert.Equal(0, item.TradeState);
+        Assert.Equal(0, h.Controller.ItemCount);
+        Assert.False(h.Controller.CanAdd(1));
+        h.Controller.Open(Tool);
+        Assert.True(h.Controller.CanAdd(1));
+        Assert.False(h.Button.Enabled);
+    }
+}

--- a/tests/AcDream.App.Tests/UI/Layout/SelectedObjectControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/SelectedObjectControllerTests.cs
@@ -77,6 +77,7 @@ public class SelectedObjectControllerTests
         public readonly Dictionary<uint, bool>   HealthTargetMap = new();
         public readonly Dictionary<uint, bool>   OwnedMap        = new();
         public readonly Dictionary<uint, string> NameMap         = new();
+        public Func<uint, string?>? ResolveName;
         public readonly Dictionary<uint, float>  HealthMap       = new();
         public readonly Dictionary<uint, bool>   HasHealthMap    = new();
         public readonly Dictionary<uint, float>  ManaMap         = new();
@@ -112,7 +113,8 @@ public class SelectedObjectControllerTests
                 },
                 isHealthTarget:  g => HealthTargetMap.TryGetValue(g, out var v) && v,
                 isOwnedByPlayer: g => OwnedMap.TryGetValue(g, out var v) && v,
-                name:            g => NameMap.TryGetValue(g, out var v) ? v : null,
+                name:            g => ResolveName is not null ? ResolveName(g)
+                    : NameMap.TryGetValue(g, out var v) ? v : null,
                 healthPercent:   g => HealthMap.TryGetValue(g, out var v) ? v : 1f,
                 hasHealth:       g => HasHealthMap.TryGetValue(g, out var v) && v,
                 stackSize:       g => StackMap.TryGetValue(g, out var v) ? v : 0u,
@@ -129,6 +131,39 @@ public class SelectedObjectControllerTests
                 isVendorSplitExempt: g => VendorSplitExemptMap.TryGetValue(g, out var v) && v,
                 isCoinstack: g => CoinstackMap.TryGetValue(g, out var v) && v,
                 coinTotal: () => CoinTotal);
+    }
+
+    [Theory]
+    [InlineData("Chainmail Basinet", 1, "Silver Chainmail Basinet")]
+    [InlineData("Silver Chainmail Basinet", 1, "Silver Chainmail Basinet")]
+    [InlineData("Chainmail Basinet", 2, "2 Silver Chainmail Basinets")]
+    public void MaterialNameMatchesAssessmentAndRefreshesOnObjectUpdate(
+        string baseName, int stackSize, string expected)
+    {
+        var (layout, nameEl, _, _) = FakeLayout();
+        var item = new ClientObject
+        {
+            ObjectId = 123u,
+            Name = baseName,
+            PluralName = "Chainmail Basinets",
+            StackSize = stackSize,
+        };
+        var names = new RetailAppraisalNameResolver(
+            new Dictionary<uint, string> { [1u] = "Silver" },
+            new CreatureDisplayNameResolver(new Dictionary<uint, string>()));
+        var h = new Harness { ResolveName = _ => names.ResolveAppropriateName(item) };
+        h.StackMap[item.ObjectId] = (uint)stackSize;
+        using var controller = h.Bind(layout);
+        h.FireSelection(item.ObjectId);
+        h.SplitQuantity.SetValue(1u);
+
+        item.MaterialType = 1u;
+        h.ObjectUpdatedHandler!(item);
+
+        Assert.Equal(expected,
+            nameEl.Children.OfType<UiText>().First().LinesProvider().Single().Text);
+        Assert.Equal(baseName, item.Name);
+        Assert.Equal(1u, h.SplitQuantity.Value);
     }
 
     // ── B1: Bind initialisation ──────────────────────────────────────────────

--- a/tests/AcDream.App.Tests/UI/RetailWindowLayoutPersistenceTests.SidePanels.cs
+++ b/tests/AcDream.App.Tests/UI/RetailWindowLayoutPersistenceTests.SidePanels.cs
@@ -1,0 +1,61 @@
+using AcDream.App.UI;
+using AcDream.App.UI.Layout;
+using AcDream.UI.Abstractions.Panels.Settings;
+
+namespace AcDream.App.Tests.UI;
+
+public sealed partial class RetailWindowLayoutPersistenceTests
+{
+    [Theory]
+    [InlineData(400f)]
+    [InlineData(580f)]
+    public void SidePanelSize_SurvivesMapSwitchAndFreshLogin(float chosenHeight)
+    {
+        string[] names = [WindowNames.Inventory, WindowNames.Character, WindowNames.Spellbook,
+            WindowNames.MapHouse, WindowNames.Options, WindowNames.SocialPanel, WindowNames.Journal];
+        var store = new SettingsStore(PathName);
+        for (int login = 0; login < 2; login++)
+        {
+            var root = new UiRoot { Width = 1280, Height = 900 };
+            using var panels = new RetailPanelUiController(root.IsWindowVisible, root.ShowWindow, root.HideWindow);
+            panels.ConfigureMainPanelFrame(new ElementInfo
+            {
+                Width = 310, Height = 372,
+                MinWidth = 310, MaxWidth = 310, MinHeight = 372, MaxHeight = 1000,
+            });
+            var handles = new List<RetailWindowHandle>();
+            for (int i = 0; i < names.Length; i++)
+            {
+                var handle = Mount(root, names[i], width: 310, height: 420 + i * 20);
+                handle.Hide();
+                handle.OuterFrame.MinHeight = handle.Height;
+                handle.OuterFrame.MaxHeight = 1000;
+                handle.OuterFrame.ResizeY = names[i] != WindowNames.MapHouse;
+                panels.RegisterMainPanel((uint)i + 1, names[i], handle);
+                handles.Add(handle);
+                Assert.Equal(372, handle.Height);
+            }
+            using var persistence = new RetailWindowLayoutPersistence(
+                root.WindowManager, store, () => "Alice", () => (1280, 900));
+            persistence.RestoreAll();
+            if (login == 0)
+            {
+                panels.SetPanelVisibility(1, true);
+                handles[0].ResizeTo(310, chosenHeight);
+            }
+            foreach (int index in new[] { 3, 2, 4, 5, 6, 1, 0, 3 })
+            {
+                panels.SetPanelVisibility((uint)index + 1, true);
+                Assert.All(handles, h => Assert.Equal(chosenHeight, h.Height));
+                Assert.Equal(ResizeEdges.Bottom, handles[index].OuterFrame.ResizableEdges);
+            }
+            if (login == 0)
+            {
+                handles[3].ResizeTo(310, chosenHeight + 20);
+                Assert.All(handles, h => Assert.Equal(chosenHeight + 20, h.Height));
+                handles[3].ResizeTo(310, chosenHeight);
+            }
+            persistence.SaveAll();
+        }
+    }
+}

--- a/tests/AcDream.App.Tests/UI/UiItemSlotTests.cs
+++ b/tests/AcDream.App.Tests/UI/UiItemSlotTests.cs
@@ -201,6 +201,18 @@ public class UiItemSlotTests
     public void CapacityFrontSprite_default() => Assert.Equal(0x06004D23u, new UiItemSlot().CapacityFrontSprite);
 
     [Fact]
+    public void StructureFill_defaultsHidden() => Assert.Equal(-1f, new UiItemSlot().StructureFill);
+
+    [Fact]
+    public void StructureSprites_defaultToTheAuthoredStructureMeter()
+    {
+        var slot = new UiItemSlot();
+
+        Assert.Equal(0x06004D24u, slot.StructureBackSprite);
+        Assert.Equal(0x06004D25u, slot.StructureFrontSprite);
+    }
+
+    [Fact]
     public void ActiveCooldownSprite_selects_the_exact_one_based_step()
     {
         uint[] sprites =

--- a/tests/AcDream.App.Tests/World/LiveObjectFrameControllerTests.cs
+++ b/tests/AcDream.App.Tests/World/LiveObjectFrameControllerTests.cs
@@ -1,4 +1,5 @@
 using AcDream.App.Settings;
+using AcDream.App.Rendering;
 using AcDream.App.Rendering.Vfx;
 using AcDream.App.Update;
 using AcDream.UI.Abstractions.Panels.Settings;
@@ -7,6 +8,27 @@ namespace AcDream.App.Tests.World;
 
 public sealed class LiveObjectFrameControllerTests
 {
+    [Fact]
+    public void SkyPesActivationBindingReleasesOnlyItsOwnGate()
+    {
+        var slot = new SkyPesActivationGateSlot();
+        var first = new RecordingSkyPesActivationGate();
+        var second = new RecordingSkyPesActivationGate();
+
+        IDisposable firstLease = slot.BindOwned(first);
+        slot.Tick();
+        Assert.Equal(1, first.Calls);
+
+        firstLease.Dispose();
+        IDisposable secondLease = slot.BindOwned(second);
+        firstLease.Dispose();
+        slot.Tick();
+        secondLease.Dispose();
+
+        Assert.Equal(1, first.Calls);
+        Assert.Equal(1, second.Calls);
+    }
+
     [Theory]
     [InlineData(ParticleRange.Retail, 1f)]
     [InlineData(
@@ -52,5 +74,12 @@ public sealed class LiveObjectFrameControllerTests
         public DisplaySettings DisplayPreview { get; set; } = display;
 
         public AudioSettings AudioPreview => AudioSettings.Default;
+    }
+
+    private sealed class RecordingSkyPesActivationGate : ISkyPesActivationGate
+    {
+        public int Calls { get; private set; }
+
+        public void Tick() => Calls++;
     }
 }

--- a/tests/AcDream.App.Tests/World/UpdateFrameOrchestratorTests.cs
+++ b/tests/AcDream.App.Tests/World/UpdateFrameOrchestratorTests.cs
@@ -351,6 +351,7 @@ public sealed class UpdateFrameOrchestratorTests
             ("LiveEntityAnimationPresenter", "Present"),
             ("EquippedChildRenderController", "Tick"),
             ("RetailStaticAnimatingObjectScheduler", "ProcessHooks"),
+            ("SkyPesActivationGateSlot", "Tick"),
             ("LiveEffectFrameController", "Tick"));
         AssertNamedCallOrder(
             RequiredMethod(typeof(LiveEffectFrameController), "Tick"),

--- a/tests/AcDream.Core.Net.Tests/GameEventWiringTests.cs
+++ b/tests/AcDream.Core.Net.Tests/GameEventWiringTests.cs
@@ -1401,6 +1401,93 @@ public sealed class GameEventWiringTests
     }
 
     [Fact]
+    public void WireAll_SalvageOperationsResult_EmitsTheSalvagingSuccessLine()
+    {
+        var lines = new List<(string Text, RetailLogTextType Type)>();
+        var dispatcher = new GameEventDispatcher();
+        GameEventWiring.WireAll(
+            dispatcher,
+            new ClientObjectTable(),
+            new CombatState(),
+            new Spellbook(),
+            new ChatLog(),
+            onInterfaceText: (text, type) => lines.Add((text, type)));
+
+        byte[] payload = new AceWireWriter()
+            .Write(28u)
+            .Write(0u)
+            .Write(1u)
+            .Write(63u).Write(unchecked((ulong)BitConverter.DoubleToInt64Bits(8d))).Write(1u)
+            .Write(0)
+            .ToArray();
+        dispatcher.Dispatch(GameEventEnvelope.TryParse(
+            WrapEnvelope(GameEventType.SalvageOperationsResult, payload))!.Value);
+
+        Assert.Equal(
+            ("You obtain 1 Silver (ws 8.00) using your knowledge of Weapon Tinkering.",
+                RetailLogTextType.Salvaging),
+            Assert.Single(lines));
+    }
+
+    [Fact]
+    public void WireAll_SalvageOperationsResult_EmitsUnsuitableItemsInSalvagingLog()
+    {
+        var lines = new List<(string Text, RetailLogTextType Type)>();
+        var items = new ClientObjectTable();
+        const uint unsuitableItem = 0x50000020u;
+        items.AddOrUpdate(new ClientObject { ObjectId = unsuitableItem, Name = "Broken Item" });
+        var dispatcher = new GameEventDispatcher();
+        GameEventWiring.WireAll(
+            dispatcher,
+            items,
+            new CombatState(),
+            new Spellbook(),
+            new ChatLog(),
+            onInterfaceText: (text, type) => lines.Add((text, type)));
+
+        byte[] payload = new AceWireWriter()
+            .Write(28u)
+            .Write(1u).Write(unsuitableItem)
+            .Write(0u)
+            .Write(0)
+            .ToArray();
+        dispatcher.Dispatch(GameEventEnvelope.TryParse(
+            WrapEnvelope(GameEventType.SalvageOperationsResult, payload))!.Value);
+
+        Assert.Equal(
+            (" The following were not suitable for salvaging: Broken Item",
+                RetailLogTextType.Salvaging),
+            Assert.Single(lines));
+    }
+
+    [Fact]
+    public void WireAll_SalvageOperationsResult_EmitsFailureInSalvagingLog()
+    {
+        var lines = new List<(string Text, RetailLogTextType Type)>();
+        var dispatcher = new GameEventDispatcher();
+        GameEventWiring.WireAll(
+            dispatcher,
+            new ClientObjectTable(),
+            new CombatState(),
+            new Spellbook(),
+            new ChatLog(),
+            onInterfaceText: (text, type) => lines.Add((text, type)));
+
+        byte[] payload = new AceWireWriter()
+            .Write(28u)
+            .Write(0u)
+            .Write(0u)
+            .Write(0)
+            .ToArray();
+        dispatcher.Dispatch(GameEventEnvelope.TryParse(
+            WrapEnvelope(GameEventType.SalvageOperationsResult, payload))!.Value);
+
+        Assert.Equal(
+            ("Salvaging Failed!", RetailLogTextType.Salvaging),
+            Assert.Single(lines));
+    }
+
+    [Fact]
     public void WireAll_PlayerDescription_PublishesCharacterOptions()
     {
         var dispatcher = new GameEventDispatcher();

--- a/tests/AcDream.Core.Net.Tests/Messages/GameEventsInventoryTests.cs
+++ b/tests/AcDream.Core.Net.Tests/Messages/GameEventsInventoryTests.cs
@@ -71,4 +71,36 @@ public sealed class GameEventsInventoryTests
         Assert.Equal(0x50000A01u, p!.Value.ItemGuid);
         Assert.Equal(0x0Au, p.Value.WeenieError);
     }
+
+    [Fact]
+    public void ParseSalvageOperationsResult_readsRejectedItemsAndResults()
+    {
+        var wire = new AceWireWriter()
+            .Write(28u)
+            .Write(1u).Write(0x50000020u)
+            .Write(1u)
+            .Write(63u).Write(unchecked((ulong)BitConverter.DoubleToInt64Bits(8d))).Write(1u)
+            .Write(25)
+            .ToArray();
+
+        GameEvents.SalvageOperationsResult? result =
+            GameEvents.ParseSalvageOperationsResult(wire);
+
+        Assert.NotNull(result);
+        Assert.Equal(28u, result!.Value.SkillId);
+        Assert.Equal([0x50000020u], result.Value.UnsuitableItemGuids);
+        GameEvents.SalvageResult material = Assert.Single(result.Value.Results);
+        Assert.Equal((63u, 8d, 1u), (material.MaterialType, material.Workmanship, material.Units));
+        Assert.Equal(25, result.Value.AugmentationBonusPercent);
+    }
+
+    [Fact]
+    public void ParseSalvageOperationsResult_truncatedResult_returnsNull()
+    {
+        var wire = new AceWireWriter()
+            .Write(28u).Write(0u).Write(1u).Write(63u)
+            .ToArray();
+
+        Assert.Null(GameEvents.ParseSalvageOperationsResult(wire));
+    }
 }


### PR DESCRIPTION
## What this changes

This release batch adds salvaging and fixes rendering and interface issues reported during gameplay. It includes all eight changes since v0.1.0, including the creature-texture and shared-panel-size commits.

### Release notes

- **Salvaging:** using a Universal Salvage Tool opens a horizontally resizable panel. Drag suitable items or containers into it, remove staged items by dragging them out or right-clicking, and press Salvage to process them. Results appear in chat and inventory. Partial salvage bags show a fill meter; full bags hide it.
- **Creature textures:** fixed missing or incorrect textures on recoloured creatures, including the Lich Lord's torso.
- **Shared side-panel size:** inventory, skills, quests, map, spellbook, allegiance, and settings now share the resized panel dimensions. Switching panels no longer resets the height, and the chosen size persists across logins.
- **Dungeon weather:** outdoor rain, thunderstorm ambience, and sky effects no longer persist inside dungeons such as the Marketplace.
- **Item names:** the selected-item/action display now includes material names consistently with assessment, such as “Silver Chainmail Basinet,” and refreshes when item information changes.
- **Inspect toggle:** pressing the inspect binding again closes the inspection window.
- **Overhead fog:** the far overhead view disables distance fog so the ground remains visible. Returning to the normal camera restores fog.
- **Building visibility:** fixed buildings disappearing in the far overhead view and missing buildings in the outer landscape rings while doors and other server-placed objects remained visible.

## Original behavior

The original client provides the UST staging flow, shared side-panel sizing, inspect toggling, and the overhead distance-fog exception. Behavior was checked against the original client and installed game data. Salvaging was verified end to end by the maintainer. Item destruction and salvage creation remain server-authoritative.

## Validation

- Release solution build: zero warnings or errors.
- Complete local Windows portable CI test set: 18,269 passed, zero failures.
- Installed salvage layout checked at 600px and 800px widths: fixed height, growing item row, and correctly anchored buttons.
- Focused interaction, item-meter, parser, and rendering regression coverage; independent review completed.
- This is an explicitly requested release batch spanning the eight fixes above.

## Checklist

- [x] `dotnet build AcDream.slnx -c Release` is green.
- [x] The complete portable test filter passes locally.
- [x] No code copied from ACEmulator, ACViewer, or holtburger.
- [x] No new comments describing the original client's internals; private source-hygiene gate passes.
