### PR TITLE
Migrate macOS config from the pre-0.1.2 XDG location

### DIFF
--- a/src/AcDream.Platform/ApplicationPathSet.cs
+++ b/src/AcDream.Platform/ApplicationPathSet.cs
@@ -123,14 +123,30 @@ public sealed record ApplicationPathSet(
                 "acdream");
         }
 
-        string? legacyConfigDirectory =
-            platform.IsWindows && configDirectory is null
-                ? Path.Combine(
+        string? legacyConfigDirectory = null;
+        if (configDirectory is null)
+        {
+            if (platform.IsWindows)
+            {
+                legacyConfigDirectory = Path.Combine(
                     RequireFolder(
                         platform,
                         Environment.SpecialFolder.LocalApplicationData),
-                    "acdream")
-                : null;
+                    "acdream");
+            }
+            else if (platform.IsMacOS)
+            {
+                legacyConfigDirectory = ResolveXdg(
+                    platform,
+                    "XDG_CONFIG_HOME",
+                    Path.Combine(
+                        RequireFolder(
+                            platform,
+                            Environment.SpecialFolder.UserProfile),
+                        ".config"),
+                    "acdream");
+            }
+        }
 
         return new ApplicationPathSet(
             Normalize(configDirectory ?? config, platform),

--- a/tests/AcDream.Platform.Tests/ApplicationPathSetTests.cs
+++ b/tests/AcDream.Platform.Tests/ApplicationPathSetTests.cs
@@ -20,6 +20,43 @@ public sealed class ApplicationPathSetTests
         Assert.Equal(Path.Combine(home, "Library", "Application Support", "acdream"), paths.DataDirectory);
         Assert.Equal(Path.Combine(paths.DataDirectory, "config"), paths.ConfigDirectory);
         Assert.Equal(Path.Combine(home, "Library", "Caches", "acdream"), paths.CacheDirectory);
+        Assert.Equal(
+            Path.Combine(home, ".config", "acdream"),
+            paths.LegacyConfigDirectory);
+    }
+
+    [Fact]
+    public void MacLegacyConfigFollowsXdgConfigHomeWhenItIsSet()
+    {
+        string home = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "mac-xdg-home"));
+        string xdg = Path.Combine(home, "xdg-config");
+        var platform = new FixtureEnvironment(isWindows: false)
+        {
+            IsMacOS = true,
+            UserProfile = home,
+            Variables = { ["XDG_CONFIG_HOME"] = xdg },
+        };
+
+        ApplicationPathSet paths = ApplicationPathSet.Resolve(platform: platform);
+
+        Assert.Equal(Path.Combine(xdg, "acdream"), paths.LegacyConfigDirectory);
+    }
+
+    [Fact]
+    public void MacHasNoLegacyConfigWhenTheConfigDirectoryIsOverridden()
+    {
+        string home = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "mac-explicit-config"));
+        var platform = new FixtureEnvironment(isWindows: false)
+        {
+            IsMacOS = true,
+            UserProfile = home,
+            CurrentDirectoryValue = home,
+        };
+
+        ApplicationPathSet paths = ApplicationPathSet.Resolve(
+            configDirectory: Path.Combine(home, "explicit"),
+            platform: platform);
+
         Assert.Null(paths.LegacyConfigDirectory);
     }
 


### PR DESCRIPTION
Fixes #17.

`c8ff131` gave macOS its own branch in `ApplicationPathSet` and moved config to
`~/Library/Application Support/acdream/config`. That destination is right. The old location was
only ever a side effect of macOS falling through to the XDG branch.

The gap is that `GraphicalLegacyConfigurationMigrator`, which exists to handle exactly this, never
runs on macOS. `LegacyConfigDirectory` was computed for Windows only:

```csharp
string? legacyConfigDirectory =
    platform.IsWindows && configDirectory is null
        ? Path.Combine(RequireFolder(platform, LocalApplicationData), "acdream")
        : null;
```

so `Migrate` exits at its first guard and a config written by 0.1.0 or 0.1.1 is left behind. On my
machine that was a 69,957 byte `settings.json` holding window positions, resolution and fullscreen,
replaced by freshly generated defaults.

This adds a macOS arm pointing at the XDG path that macOS used before the move, honoring
`XDG_CONFIG_HOME` the same way the Linux branch does. The migrator already refuses to overwrite a
destination that exists, so a fresh install is unaffected and a second launch does nothing.

**Tests**

The existing `MacUsesApplicationSupportAndCachesOutsideTheApplicationBundle` asserted that
`LegacyConfigDirectory` was null, which encoded the gap. It now asserts the legacy path. Two cases
are added for `XDG_CONFIG_HOME` being set, and for an explicit config directory override leaving
the legacy path null.

All three run in the portable lane through `IApplicationPathEnvironment`, so they need no Mac.

**Verification**

Against `a5a6e5d` without the source change, the two path tests fail. With it, all nine in
`ApplicationPathSetTests` pass.

Full gate on macOS arm64, SDK 10.0.303:

```
build: 0 warnings, 0 errors
portable filter: passed=18318 failed=2
```

The passing count is up by exactly the two tests added here.

Before this change I confirmed the fix by hand: copying the stranded `settings.json` to the new
path restored the configuration and it survived a restart, which is the same copy the migrator
performs.

**Not covered**

Only `settings.json` and `keybinds.json` move, because that is the list the migrator already
carries. Anything else written to the old location by an earlier release stays there.

I have not tested this on Windows or Linux. The Windows arm is unchanged, and the Linux branch has
no legacy path before or after.