### PR TITLE
Keep the macOS window fullscreen across focus changes

### DIFF
--- a/src/AcDream.App/Settings/DisplayModeSwitching.cs
+++ b/src/AcDream.App/Settings/DisplayModeSwitching.cs
@@ -25,6 +25,10 @@ internal sealed unsafe class GlfwDisplayModeSwitcher : IDisplayModeSwitcher
 
     private static (int X, int Y) _windowedPosition = (60, 60);
 
+    private static bool MacOsHost { get; } =
+        AcDream.App.Platform.GraphicalHostPlatformServices.DetectOperatingSystem()
+            == AcDream.App.Platform.GraphicalHostOperatingSystem.MacOS;
+
     public GlfwDisplayModeSwitcher(IWindow window)
     {
         _window = window ?? throw new ArgumentNullException(nameof(window));
@@ -100,6 +104,15 @@ internal sealed unsafe class GlfwDisplayModeSwitcher : IDisplayModeSwitcher
                 // restore it (GLFW does not remember it for us).
                 glfw.GetWindowPos(handle, out int x, out int y);
                 _windowedPosition = (x, y);
+            }
+
+            // GLFW_AUTO_ICONIFY restores the desktop video mode on focus loss.
+            if (MacOsHost)
+            {
+                glfw.SetWindowAttrib(
+                    handle,
+                    WindowAttributeSetter.AutoIconify,
+                    false);
             }
 
             glfw.SetWindowMonitor(handle, monitor, 0, 0, width, height, refresh);


### PR DESCRIPTION
Fixes #19.

`GLFW_AUTO_ICONIFY` defaults to true, so a fullscreen window iconifies and the desktop video mode
is restored whenever the window loses focus, then re-applied when it regains focus.
`GlfwDisplayModeSwitcher.TryEnterFullscreen` attaches a monitor, which makes that a real mode
change:

```
display: fullscreen mode switch 1920x1080@144
```

On macOS each mode change blanks the display. Switching to another application and back means two
of them.

This turns the attribute off when entering fullscreen on macOS, so the window keeps its mode across
focus changes. Windows and Linux keep the GLFW default and are unchanged, because I cannot test
whether they want the same treatment.

**Measurements, on an Apple M5 Pro**

With a display running at a resolution that does not match the game's fullscreen mode, switching
away blanked the whole display for several seconds in each direction. After matching the monitor
resolution that improved a great deal on its own, to under a second with no flashing. So the
severity depends heavily on the display configuration, and my original report overstated the
typical case.

The remaining difference is still visible. Tested back to back on the same hardware and the same
display configuration, only the one attribute differing:

- without the change: a brief blank on the way out and again on the way back along with forced minimizing of the client
- with the change: no visible interruption at all, and audio is uninterrupted

I built both, switched between them, and re-tested after changing the monitor specifically to rule
out the display change being responsible. It is not: the blank still occurs without this change on
various monitor arrangements.

**Where the platform check lives**

`LinuxPlatformBoundaryTests` keeps `OperatingSystem` checks inside `Platform/` and the named frame
pacing files, so this reads the host that `Platform/` already detects rather than testing the
operating system in `Settings/`.

**Tradeoffs**

With auto-iconify off, the display stays at the game's fullscreen mode while you are in another
application, so other windows are at the game's resolution rather than the desktop's. That is the
usual trade for this behavior on Mac, and it is why I gated it to macOS rather than applying it
everywhere.

The alternative is borderless windowed fullscreen: no mode change at all, instant switching, other
applications unaffected, at the cost of rendering at the full native resolution unless there is a
separate internal render scale. That is a larger change and it depends on how you want render
scaling to work, so I have not attempted it. If you would rather go that way, this pull request is
the wrong shape and should be closed.

**Gate**

macOS arm64, SDK 10.0.303:

```
build: 0 warnings, 0 errors
portable filter: passed=18316 failed=2
```

The two failures are `LauncherHeadlessCommandLineContractTests.GraphicalArgumentsAreNotAHeadless
CommandLine` for `Gui` and `GuiSelect`, which already fail on a clean `a5a6e5d` checkout on macOS
and are unrelated to this change.

**Not covered**

No automated test. `GlfwDisplayModeSwitcher` talks to a live GLFW window, so the behavior is only
observable by switching focus on a real machine. The verification above is by hand.