### PR TITLE
Retain the skills list scroll position

### DIFF
--- a/src/AcDream.App/UI/Layout/CharacterStatController.cs
+++ b/src/AcDream.App/UI/Layout/CharacterStatController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using AcDream.App.UI;
 
@@ -358,6 +359,11 @@ public static class CharacterStatController
         {
             if (statList is null) return;
 
+            // The rebuild replaces the viewport, so its scroll model is new.
+            int previousScrollY = activeListEntries
+                .OfType<UiScrollablePanel>()
+                .FirstOrDefault()?.Scroll.ScrollY ?? 0;
+
             foreach (var entry in activeListEntries)
                 statList.RemoveChild(entry);
             activeListEntries.Clear();
@@ -390,6 +396,14 @@ public static class CharacterStatController
             {
                 currentAttributeRows = BuildAttributeRows(viewport, rowDatFont, spriteResolve, data, attrSel,
                     allRaise1, allRaise10, SetFooterSelected, iconDidResolve);
+            }
+
+            if (previousScrollY > 0)
+            {
+                // SetScrollY clamps against MaxScroll, which is zero until the
+                // scroll model has the rebuilt content and view heights.
+                viewport.LayoutScrollableChildren();
+                viewport.Scroll.SetScrollY(previousScrollY);
             }
 
             if (skillScrollbar is not null)

--- a/tests/AcDream.App.Tests/UI/Layout/CharacterStatControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/CharacterStatControllerTests.cs
@@ -1181,6 +1181,46 @@ public class CharacterStatControllerTests
         Assert.Equal(trainedBefore + 1, RowsUnderHeader(list, "Trained Skills"));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataChangedRefresh_PreservesSkillsScrollWithinTheNewContentBounds(
+        bool shrinkSkills)
+    {
+        var list = new UiPanel { Width = 300, Height = 60 };
+        var layout = Fake((CharacterStatController.ListBoxId, list));
+        CharacterSheet sheet = SampleData.SampleCharacter();
+        Action refresh = CharacterStatController.Bind(layout, () => sheet,
+            spriteResolve: id => (id, 16, 16)).Refresh;
+
+        ClickTab(layout, left: 92f);
+        UiScrollablePanel previous = list.Children.OfType<UiScrollablePanel>().Single();
+        previous.LayoutScrollableChildren();
+        Assert.True(previous.Scroll.MaxScroll > 10);
+        int offset = previous.Scroll.MaxScroll - 10;
+        previous.Scroll.SetScrollY(offset);
+
+        sheet = new CharacterSheet
+        {
+            Name = sheet.Name,
+            UnassignedXp = sheet.UnassignedXp + 1,
+            SkillCredits = sheet.SkillCredits,
+            Skills = shrinkSkills ? sheet.Skills.Take(6).ToList() : sheet.Skills,
+        };
+        refresh();
+
+        UiScrollablePanel replacement = list.Children.OfType<UiScrollablePanel>().Single();
+        Assert.NotSame(previous, replacement);
+        if (shrinkSkills)
+        {
+            Assert.True(replacement.Scroll.MaxScroll > 0);
+            Assert.True(replacement.Scroll.MaxScroll < offset);
+        }
+        Assert.Equal(Math.Min(offset, replacement.Scroll.MaxScroll), replacement.Scroll.ScrollY);
+        if (!shrinkSkills)
+            Assert.Equal(offset, replacement.Scroll.ScrollY);
+    }
+
     [Fact]
     public void Rows_CarryTheSharedTooltipPopupLocatorAndDescriptionText()
     {


### PR DESCRIPTION
Fixes #22.

`CharacterStatController.RebuildActiveList` replaces the `UiScrollablePanel` that holds the rows,
so the rebuilt list comes back with a fresh scroll model sitting at the top. The character sheet
subscription fires on routine player object updates rather than only on skill changes, so the
panel rebuilds every few seconds and the player loses their place while reading it.

Attributes is unaffected only because that list is short enough not to scroll, so the same reset
is invisible there.

`Refresh` already preserves the selected skill across this rebuild, a few lines above. This does
the same for scroll position.

**Verification**

Reproduced first, confirmed by another tester on the issue and by me on macOS. Built both ways and
tested back to back: without the change the skills list jumps to the top every few seconds while
scrolled; with it the position holds across the same updates.

macOS arm64, SDK 10.0.303:

```
build: 0 warnings, 0 errors
portable filter: passed=18316 failed=2
```

The two failures are `LauncherHeadlessCommandLineContractTests.GraphicalArgumentsAreNotAHeadless
CommandLine` for `Gui` and `GuiSelect`, which already fail on a clean `a5a6e5d` checkout on macOS
and are unrelated to this change.

**No automated test**, because the behavior lives in a closure inside `Bind` that needs a real
layout and a live scroll model. If you want one I am happy to add it, but it looked like it would
need the method broken up, which felt out of proportion for the fix.

**An observation rather than a proposal**

Preserving state across a rebuild is now done twice in this method, for selection and for scroll.
The underlying reason is that a sheet change rebuilds every row rather than updating the rows that
changed. Updating in place would make both workarounds unnecessary and would stop the panel
rebuilding on updates that do not touch it. That is a bigger change across every retained panel
and it is your call, so I have not attempted it. If you are interested in a per-line update or an MVVM binding solution I would be happy to send a follow-on PR.