### PR TITLE
Fix indoor first-entry stuck on Expected collision generation

### DIFF
--- a/src/AcDream.Runtime/Physics/RuntimePhysicsState.cs
+++ b/src/AcDream.Runtime/Physics/RuntimePhysicsState.cs
@@ -1823,6 +1823,11 @@ public sealed class RuntimePhysicsState : IDisposable
                 acknowledgement.LandblockId,
                 acknowledgement.Generation,
                 acknowledgement.Ready));
+        // Admission is closed → prefix admissible. Recover any deferred ops
+        // under this landblock whose spawn cell is ready (unbound or stale
+        // Expected) so dormant first-entry does not wait for a later Evaluate.
+        _ = SetPosition.TryRecoverDeferredForLandblock(
+            acknowledgement.LandblockId);
         return new RuntimeCollisionGenerationCommit(
             acknowledgement,
             Array.Empty<uint>(),

--- a/src/AcDream.Runtime/Physics/RuntimeSetPositionState.cs
+++ b/src/AcDream.Runtime/Physics/RuntimeSetPositionState.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using AcDream.Content;
@@ -1786,14 +1786,39 @@ internal sealed class RuntimeSetPositionState : IDisposable
             return 0;
         }
 
+        var retries = new List<RuntimeEntityPlacementToken>();
         int recovered = RecoverUnboundDeferredOntoAuthority(
             cellId,
             prefix,
-            authority);
+            authority,
+            retries);
         recovered += RecoverStaleExpectedDeferredOntoAuthority(
             cellId,
             prefix,
-            authority);
+            authority,
+            retries);
+
+        // Every survivor must be indexed before placement observers can start
+        // another admission. Callbacks may replace operations or authority.
+        foreach (RuntimeEntityPlacementToken token in retries)
+        {
+            if (_physics.CollisionGenerationAuthority(cellId) != authority
+                || !_physics.IsCollisionEvaluationPrefixAdmissible(cellId)
+                || !_physics.Engine.IsSpawnCellReady(cellId))
+            {
+                break;
+            }
+            if (IsCurrentByToken(token.Entity, token, out Operation? operation)
+                && operation.WakeableLostCell
+                && operation.ExactCellId == cellId
+                && operation.CollisionPrefix == prefix
+                && operation.CollisionGeneration == authority
+                && operation.CollisionGenerationReady
+                && operation.WithdrawalAcknowledged)
+            {
+                RetryDeferred(operation, preserveDeferredOrder: true);
+            }
+        }
         return recovered;
     }
 
@@ -1832,7 +1857,8 @@ internal sealed class RuntimeSetPositionState : IDisposable
     private int RecoverUnboundDeferredOntoAuthority(
         uint cellId,
         uint prefix,
-        ulong authority)
+        ulong authority,
+        List<RuntimeEntityPlacementToken> retries)
     {
         var unboundKey = new UnboundCellKey(cellId, prefix);
         if (!_unboundDeferredByCell.Remove(
@@ -1859,7 +1885,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
                 continue;
             }
 
-            MarkDeferredRecoveredOntoAuthority(operation, authority);
+            MarkDeferredRecoveredOntoAuthority(operation, authority, retries);
             recovered++;
         }
 
@@ -1875,7 +1901,8 @@ internal sealed class RuntimeSetPositionState : IDisposable
     private int RecoverStaleExpectedDeferredOntoAuthority(
         uint cellId,
         uint prefix,
-        ulong authority)
+        ulong authority,
+        List<RuntimeEntityPlacementToken> retries)
     {
         // Ops parked on Expected (typically authority+1) after the landblock
         // already committed never receive a matching CommitCollisionGeneration.
@@ -1912,7 +1939,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
                     continue;
                 }
 
-                MarkDeferredRecoveredOntoAuthority(operation, authority);
+                MarkDeferredRecoveredOntoAuthority(operation, authority, retries);
                 recovered++;
             }
         }
@@ -1922,19 +1949,19 @@ internal sealed class RuntimeSetPositionState : IDisposable
 
     private void MarkDeferredRecoveredOntoAuthority(
         Operation operation,
-        ulong authority)
+        ulong authority,
+        List<RuntimeEntityPlacementToken> retries)
     {
         ulong prior = operation.CollisionGeneration;
         operation.CollisionGeneration = authority;
         operation.CollisionGenerationReady = true;
+        IndexDeferred(operation);
+        retries.Add(operation.Token);
         if (Core.Physics.PhysicsDiagnostics.ProbeParkEnabled)
         {
             Console.WriteLine(FormattableString.Invariant(
                 $"[wake] recover-spawn cell=0x{operation.ExactCellId:X8} gen={authority} (was {prior}) guid=0x{operation.Record.ServerGuid:X8} dormant={operation.DormantLocalActivation}"));
         }
-
-        if (operation.WithdrawalAcknowledged)
-            RetryDeferred(operation);
     }
 
     internal bool TryPrepareDormantLocalActivationCommit(
@@ -4074,7 +4101,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
             projection);
     }
 
-    private void RetryDeferred(Operation operation)
+    private void RetryDeferred(Operation operation, bool preserveDeferredOrder = false)
     {
         if (operation.DormantLocalActivation)
             return;
@@ -4108,7 +4135,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
             }
             else
             {
-                UnindexDeferred(operation);
+                UnindexDeferred(operation, preserveDeferredOrder);
                 operation.CollisionPrefix = blocking.Token.LandblockPrefix;
                 operation.CollisionGeneration = blocking.Token.CollisionGeneration;
                 operation.CollisionGenerationReady = false;
@@ -4119,7 +4146,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
             }
         }
 
-        UnindexDeferred(operation);
+        UnindexDeferred(operation, preserveDeferredOrder);
         operation.CollisionQuiescenceHeld = false;
         operation.Command = operation.Command with
         {
@@ -4997,7 +5024,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
             entities.Add(operation.Key);
     }
 
-    private void UnindexDeferred(Operation operation)
+    private void UnindexDeferred(Operation operation, bool preserveOrder = false)
     {
         if (operation.ExactCellId == 0u)
         {
@@ -5016,8 +5043,9 @@ internal sealed class RuntimeSetPositionState : IDisposable
                 if (unboundIndex >= 0)
                 {
                     int last = unbound.Count - 1;
-                    unbound[unboundIndex] = unbound[last];
-                    unbound.RemoveAt(last);
+                    if (!preserveOrder)
+                        unbound[unboundIndex] = unbound[last];
+                    unbound.RemoveAt(preserveOrder ? unboundIndex : last);
                 }
                 if (unbound.Count == 0)
                 {
@@ -5039,8 +5067,9 @@ internal sealed class RuntimeSetPositionState : IDisposable
             if (index >= 0)
             {
                 int last = entities.Count - 1;
-                entities[index] = entities[last];
-                entities.RemoveAt(last);
+                if (!preserveOrder)
+                    entities[index] = entities[last];
+                entities.RemoveAt(preserveOrder ? index : last);
             }
             if (entities.Count == 0)
                 RemoveDeferredBucket(bucket);

--- a/src/AcDream.Runtime/Physics/RuntimeSetPositionState.cs
+++ b/src/AcDream.Runtime/Physics/RuntimeSetPositionState.cs
@@ -160,6 +160,7 @@ internal sealed class PreparedDormantSetPositionCommit
     internal required SortedDictionary<ulong, RuntimePlacementProjectionSnapshot>?
         PendingProjection { get; init; }
     internal required ulong DeferredCollisionGeneration { get; init; }
+    internal required bool DeferredCollisionGenerationReady { get; init; }
     internal required List<RuntimeEntityKey>? DeferredBucket { get; init; }
     internal required bool DeferredBucketIsNew { get; init; }
 }
@@ -1564,6 +1565,16 @@ internal sealed class RuntimeSetPositionState : IDisposable
         ArgumentNullException.ThrowIfNull(record);
         ArgumentNullException.ThrowIfNull(body);
         evaluation = default;
+        // Deferred dormant leases stay "current" while unbound, so TryRearm is
+        // skipped by the short-circuit below. Recover spawn-ready indoor cells
+        // first so rearm can publish first-entry after a stranded commit.
+        if (_operations.TryGetValue(token.Entity, out Operation? pending)
+            && pending.WakeableLostCell
+            && pending.ExactCellId != 0u)
+        {
+            TryRecoverUnboundDeferredWhenSpawnReady(pending.ExactCellId);
+        }
+
         if (!IsExactDormantLocalActivationCurrent(
                 record,
                 body,
@@ -1748,6 +1759,184 @@ internal sealed class RuntimeSetPositionState : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// When an indoor spawn EnvCell becomes ready after its landblock collision
+    /// generation already committed, rebind stranded deferred ops onto that
+    /// authority and wake them. Covers both:
+    /// - unbound (gen==0) ops left by CommitCollisionGeneration when spawn was
+    ///   not ready at commit time, and
+    /// - ops parked on Expected (authority+1) because first-entry activated
+    ///   after authority already existed — no later admission ever commits that
+    ///   future generation, so dormant local first-entry stays unpublished.
+    /// </summary>
+    internal int TryRecoverUnboundDeferredWhenSpawnReady(uint cellId)
+    {
+        EnsureNotDisposed();
+        if (cellId == 0u
+            || !_physics.Engine.IsSpawnCellReady(cellId))
+        {
+            return 0;
+        }
+
+        uint prefix = cellId & 0xFFFF0000u;
+        ulong authority = _physics.CollisionGenerationAuthority(cellId);
+        if (authority == 0UL
+            || !_physics.IsCollisionEvaluationPrefixAdmissible(cellId))
+        {
+            return 0;
+        }
+
+        int recovered = RecoverUnboundDeferredOntoAuthority(
+            cellId,
+            prefix,
+            authority);
+        recovered += RecoverStaleExpectedDeferredOntoAuthority(
+            cellId,
+            prefix,
+            authority);
+        return recovered;
+    }
+
+    /// <summary>
+    /// After a collision admission fully closes, scan deferred ops under the
+    /// landblock whose spawn cells are already ready and recover them now that
+    /// the prefix is admissible.
+    /// </summary>
+    internal int TryRecoverDeferredForLandblock(uint landblockId)
+    {
+        EnsureNotDisposed();
+        uint prefix = landblockId & 0xFFFF0000u;
+        if (prefix == 0u)
+            return 0;
+
+        var cells = new HashSet<uint>();
+        for (int index = 0; index < _unboundDeferredCellOrder.Count; index++)
+        {
+            UnboundCellKey key = _unboundDeferredCellOrder[index];
+            if (key.CollisionPrefix == prefix)
+                cells.Add(key.CellId);
+        }
+        for (int index = 0; index < _deferredBucketOrder.Count; index++)
+        {
+            CellGenerationKey key = _deferredBucketOrder[index];
+            if (key.CollisionPrefix == prefix)
+                cells.Add(key.CellId);
+        }
+
+        int recovered = 0;
+        foreach (uint cellId in cells)
+            recovered += TryRecoverUnboundDeferredWhenSpawnReady(cellId);
+        return recovered;
+    }
+
+    private int RecoverUnboundDeferredOntoAuthority(
+        uint cellId,
+        uint prefix,
+        ulong authority)
+    {
+        var unboundKey = new UnboundCellKey(cellId, prefix);
+        if (!_unboundDeferredByCell.Remove(
+                unboundKey,
+                out List<RuntimeEntityKey>? retained))
+        {
+            return 0;
+        }
+
+        _unboundDeferredCellOrder.Remove(unboundKey);
+        int recovered = 0;
+        List<RuntimeEntityKey>? leftover = null;
+        for (int index = 0; index < retained.Count; index++)
+        {
+            RuntimeEntityKey entity = retained[index];
+            if (!_operations.TryGetValue(entity, out Operation? operation)
+                || !operation.WakeableLostCell
+                || operation.ExactCellId != cellId
+                || operation.CollisionPrefix != prefix
+                || operation.CollisionGeneration != 0UL)
+            {
+                leftover ??= [];
+                leftover.Add(entity);
+                continue;
+            }
+
+            MarkDeferredRecoveredOntoAuthority(operation, authority);
+            recovered++;
+        }
+
+        if (leftover is { Count: > 0 })
+        {
+            _unboundDeferredByCell.Add(unboundKey, leftover);
+            _unboundDeferredCellOrder.Add(unboundKey);
+        }
+
+        return recovered;
+    }
+
+    private int RecoverStaleExpectedDeferredOntoAuthority(
+        uint cellId,
+        uint prefix,
+        ulong authority)
+    {
+        // Ops parked on Expected (typically authority+1) after the landblock
+        // already committed never receive a matching CommitCollisionGeneration.
+        CellGenerationKey[] stale = _deferredBucketOrder
+            .Where(key => key.CellId == cellId
+                && key.CollisionPrefix == prefix
+                && key.CollisionGeneration != authority)
+            .ToArray();
+        if (stale.Length == 0)
+            return 0;
+
+        int recovered = 0;
+        for (int bucketIndex = 0; bucketIndex < stale.Length; bucketIndex++)
+        {
+            CellGenerationKey bucket = stale[bucketIndex];
+            if (!_deferredByCellGeneration.TryGetValue(
+                    bucket,
+                    out List<RuntimeEntityKey>? indexed))
+            {
+                continue;
+            }
+
+            RuntimeEntityKey[] entities = indexed.ToArray();
+            RemoveDeferredBucket(bucket);
+            for (int index = 0; index < entities.Length; index++)
+            {
+                RuntimeEntityKey entity = entities[index];
+                if (!_operations.TryGetValue(entity, out Operation? operation)
+                    || !operation.WakeableLostCell
+                    || operation.ExactCellId != cellId
+                    || operation.CollisionPrefix != prefix
+                    || operation.CollisionGeneration != bucket.CollisionGeneration)
+                {
+                    continue;
+                }
+
+                MarkDeferredRecoveredOntoAuthority(operation, authority);
+                recovered++;
+            }
+        }
+
+        return recovered;
+    }
+
+    private void MarkDeferredRecoveredOntoAuthority(
+        Operation operation,
+        ulong authority)
+    {
+        ulong prior = operation.CollisionGeneration;
+        operation.CollisionGeneration = authority;
+        operation.CollisionGenerationReady = true;
+        if (Core.Physics.PhysicsDiagnostics.ProbeParkEnabled)
+        {
+            Console.WriteLine(FormattableString.Invariant(
+                $"[wake] recover-spawn cell=0x{operation.ExactCellId:X8} gen={authority} (was {prior}) guid=0x{operation.Record.ServerGuid:X8} dormant={operation.DormantLocalActivation}"));
+        }
+
+        if (operation.WithdrawalAcknowledged)
+            RetryDeferred(operation);
+    }
+
     internal bool TryPrepareDormantLocalActivationCommit(
         RuntimeEntityRecord record,
         PhysicsBody body,
@@ -1780,6 +1969,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
         SortedDictionary<ulong, RuntimePlacementProjectionSnapshot>?
             pendingProjection = null;
         ulong deferredCollisionGeneration = 0UL;
+        bool deferredCollisionGenerationReady = false;
         List<RuntimeEntityKey>? deferredBucket = null;
         bool deferredBucketIsNew = false;
 
@@ -1803,8 +1993,22 @@ internal sealed class RuntimeSetPositionState : IDisposable
 
         if (result.IsDeferred)
         {
-            deferredCollisionGeneration = _physics
-                .ExpectedCollisionGeneration(result.CellId);
+            // When the spawn EnvCell is already ready under a committed,
+            // admissible landblock authority, park on that authority with
+            // ready=true so TryRearm can publish first-entry immediately.
+            // Parking on Expected (authority+1) waits forever if no later
+            // admission runs — the indoor login strand after world-reveal
+            // already reports ready.
+            ulong authority = _physics.CollisionGenerationAuthority(result.CellId);
+            bool spawnReady = result.CellId != 0u
+                && _physics.Engine.IsSpawnCellReady(result.CellId);
+            bool admissible = result.CellId != 0u
+                && _physics.IsCollisionEvaluationPrefixAdmissible(result.CellId);
+            bool wakeImmediately = authority != 0UL && spawnReady && admissible;
+            deferredCollisionGeneration = wakeImmediately
+                ? authority
+                : _physics.ExpectedCollisionGeneration(result.CellId);
+            deferredCollisionGenerationReady = wakeImmediately;
             _preparedMovers.EnsureCapacity(_preparedMovers.Count + 1);
             if (result.CellId != 0u && deferredCollisionGeneration != 0UL)
             {
@@ -1898,6 +2102,7 @@ internal sealed class RuntimeSetPositionState : IDisposable
             Projection = projection,
             PendingProjection = pendingProjection,
             DeferredCollisionGeneration = deferredCollisionGeneration,
+            DeferredCollisionGenerationReady = deferredCollisionGenerationReady,
             DeferredBucket = deferredBucket,
             DeferredBucketIsNew = deferredBucketIsNew,
         };
@@ -1953,7 +2158,8 @@ internal sealed class RuntimeSetPositionState : IDisposable
             operation.CollisionGeneration = prepared
                 .DeferredCollisionGeneration;
             operation.CollisionPrefix = result.CellId & 0xFFFF0000u;
-            operation.CollisionGenerationReady = false;
+            operation.CollisionGenerationReady = prepared
+                .DeferredCollisionGenerationReady;
             operation.Stage = RuntimeEntityPlacementStage.AwaitingCell;
             _preparedMovers[operation.Key] = prepared.Evaluation.Command.Physics;
             if (prepared.DeferredBucket is { } deferredBucket)

--- a/tests/AcDream.Runtime.Tests/Gameplay/RuntimeLocalPlayerPhysicsPublicationStateTests.cs
+++ b/tests/AcDream.Runtime.Tests/Gameplay/RuntimeLocalPlayerPhysicsPublicationStateTests.cs
@@ -5,9 +5,13 @@ using AcDream.Core.Net;
 using AcDream.Core.Net.Messages;
 using AcDream.Core.Physics;
 using AcDream.Core.Physics.Motion;
+using AcDream.Core.World.Cells;
 using AcDream.Runtime.Entities;
 using AcDream.Runtime.Gameplay;
 using AcDream.Runtime.Physics;
+using BSPNodeType = DatReaderWriter.Enums.BSPNodeType;
+using CellBSPNode = DatReaderWriter.Types.CellBSPNode;
+using CellBSPTree = DatReaderWriter.Types.CellBSPTree;
 
 namespace AcDream.Runtime.Tests.Gameplay;
 
@@ -553,6 +557,116 @@ public sealed class RuntimeLocalPlayerPhysicsPublicationStateTests
         Assert.True(fixture.Movement.Controller!.IsRuntimePublished);
         Assert.Equal(0, fixture.Owner.CaptureOwnership()
             .PendingActivationCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void IndoorDormantActivationRecoversOnCommittedAuthorityWithoutAnotherAdmission(bool unbound)
+    {
+        const uint indoorCell = (Cell & 0xFFFF0000u) | 0x0101u;
+        using var fixture = new Fixture(preparePlacement: false, cell: indoorCell);
+        if (!unbound)
+            CommitProductionCollisionGeneration(fixture, indoorCell & 0xFFFF0000u);
+        fixture.RepreparePlacement();
+        Assert.Equal(RuntimeLocalPlayerPhysicsPublicationStatus.Committed,
+            fixture.Owner.Commit(fixture.Prepare(), out var token));
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.DeferredCell,
+            fixture.Owner.EvaluateActivation(token, out var deferred));
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.DeferredCell,
+            fixture.Owner.CommitActivation(deferred, out _));
+        if (unbound)
+            CommitProductionCollisionGeneration(fixture, indoorCell & 0xFFFF0000u);
+        ulong authority = fixture.Lifetime.Physics.CollisionGenerationAuthority(indoorCell);
+        Assert.NotEqual(0UL, authority);
+        Assert.Equal(unbound ? 1 : 0, fixture.Lifetime.Physics.CaptureOwnership()
+            .UnboundDeferredSetPositionCellCount);
+        Assert.False(fixture.Movement.Controller!.IsRuntimePublished);
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.DeferredCell,
+            fixture.Owner.EvaluateActivation(token, out var waiting));
+        Assert.False(waiting.IsValid);
+
+        AddSyntheticIndoorCell(fixture.Lifetime.Physics.DataCache, indoorCell);
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.Evaluated,
+            fixture.Owner.EvaluateActivation(token, out var ready));
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.Committed,
+            fixture.Owner.CommitActivation(ready, out var projection));
+        Assert.True(projection.IsValid);
+        Assert.True(fixture.Movement.Controller.IsRuntimePublished);
+        Assert.True(fixture.Record.PhysicsBody!.InWorld);
+        Assert.Equal(indoorCell, fixture.Record.PhysicsBody.CellPosition.ObjCellId);
+        Assert.Equal(authority, fixture.Lifetime.Physics.CollisionGenerationAuthority(indoorCell));
+        Assert.Equal(0, fixture.Owner.CaptureOwnership().PendingActivationCount);
+        Assert.Equal(0, fixture.Lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+        Assert.Equal(0, fixture.Lifetime.Physics.CaptureOwnership().UnboundDeferredSetPositionCellCount);
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.RejectedAuthority,
+            fixture.Owner.CommitActivation(ready, out _));
+    }
+
+    [Fact]
+    public void DeferredIndoorEvaluationCommittedAfterCellArrivesCanRearmImmediately()
+    {
+        const uint indoorCell = (Cell & 0xFFFF0000u) | 0x0101u;
+        using var fixture = new Fixture(preparePlacement: false, cell: indoorCell);
+        CommitProductionCollisionGeneration(fixture, indoorCell & 0xFFFF0000u);
+        fixture.RepreparePlacement();
+        Assert.Equal(RuntimeLocalPlayerPhysicsPublicationStatus.Committed,
+            fixture.Owner.Commit(fixture.Prepare(), out var token));
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.DeferredCell,
+            fixture.Owner.EvaluateActivation(token, out var deferred));
+
+        AddSyntheticIndoorCell(fixture.Lifetime.Physics.DataCache, indoorCell);
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.DeferredCell,
+            fixture.Owner.CommitActivation(deferred, out _));
+        // Already parked ready on the committed generation; no recovery is needed.
+        Assert.Equal(1, fixture.Lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+        Assert.False(fixture.Movement.Controller!.IsRuntimePublished);
+        Assert.Equal(0, fixture.Lifetime.Physics.SetPosition
+            .TryRecoverUnboundDeferredWhenSpawnReady(indoorCell));
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.Evaluated,
+            fixture.Owner.EvaluateActivation(token, out var ready));
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.Committed,
+            fixture.Owner.CommitActivation(ready, out _));
+        Assert.True(fixture.Movement.Controller!.IsRuntimePublished);
+        Assert.Equal(indoorCell, fixture.Record.PhysicsBody!.CellPosition.ObjCellId);
+        Assert.Equal(0, fixture.Owner.CaptureOwnership().PendingActivationCount);
+    }
+
+    [Fact]
+    public void SpawnReadyIndoorActivationStillWaitsForThePendingAdmission()
+    {
+        const uint indoorCell = (Cell & 0xFFFF0000u) | 0x0101u;
+        using var fixture = new Fixture(preparePlacement: false, cell: indoorCell);
+        CommitProductionCollisionGeneration(fixture, indoorCell & 0xFFFF0000u);
+        fixture.RepreparePlacement();
+        Assert.Equal(RuntimeLocalPlayerPhysicsPublicationStatus.Committed,
+            fixture.Owner.Commit(fixture.Prepare(), out var token));
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.DeferredCell,
+            fixture.Owner.EvaluateActivation(token, out var deferred));
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.DeferredCell,
+            fixture.Owner.CommitActivation(deferred, out _));
+
+        RuntimeCollisionAdmission admission = fixture.Lifetime.Physics
+            .BeginCollisionAdmission(indoorCell & 0xFFFF0000u);
+        AddSyntheticIndoorCell(fixture.Lifetime.Physics.DataCache, indoorCell);
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.DeferredCell,
+            fixture.Owner.EvaluateActivation(token, out var waiting));
+        Assert.False(waiting.IsValid);
+        Assert.False(fixture.Movement.Controller!.IsRuntimePublished);
+        Assert.False(fixture.Record.PhysicsBody!.InWorld);
+
+        using PreparedLandblockCollisionGeneration prepared = fixture.Lifetime.Physics
+            .PrepareCollisionGeneration(admission);
+        fixture.Lifetime.Physics.StageCollisionAssets(
+            admission, prepared, CollisionAssets(indoorCell & 0xFFFF0000u));
+        AddSyntheticIndoorCell(prepared.DataCache, indoorCell);
+        Assert.True(CommitPrepared(fixture.Lifetime.Physics, admission, prepared).Committed);
+        Assert.Equal(RuntimeLocalPlayerPhysicsActivationStatus.Evaluated,
+            fixture.Owner.EvaluateActivation(token, out var ready));
+        Assert.Equal(RuntimeDormantSetPositionCommitStatus.Committed,
+            fixture.Owner.CommitActivation(ready, out _));
+        Assert.True(fixture.Movement.Controller.IsRuntimePublished);
+        Assert.Equal(0, fixture.Owner.CaptureOwnership().PendingActivationCount);
     }
 
     [Fact]
@@ -2501,7 +2615,8 @@ public sealed class RuntimeLocalPlayerPhysicsPublicationStateTests
             Vector3? initialVelocity = null,
             Vector3? initialOmega = null,
             float? initialFriction = null,
-            float? initialElasticity = null)
+            float? initialElasticity = null,
+            uint cell = Cell)
         {
             _moverSphereOriginZ = moverSphereOriginZ;
             if (residentWorld)
@@ -2540,7 +2655,8 @@ public sealed class RuntimeLocalPlayerPhysicsPublicationStateTests
                     initialVelocity,
                     initialOmega,
                     initialFriction,
-                    initialElasticity)).Canonical!;
+                    initialElasticity,
+                    cell)).Canonical!;
             Identity.ServerGuid = Record.ServerGuid;
             ActivationPreparation = new(
                 Radius: 0.48f,
@@ -2666,10 +2782,11 @@ public sealed class RuntimeLocalPlayerPhysicsPublicationStateTests
         Vector3? initialVelocity = null,
         Vector3? initialOmega = null,
         float? initialFriction = null,
-        float? initialElasticity = null)
+        float? initialElasticity = null,
+        uint cell = Cell)
     {
         var position = new CreateObject.ServerPosition(
-            Cell,
+            cell,
             1f,
             2f,
             3f,
@@ -2788,6 +2905,29 @@ public sealed class RuntimeLocalPlayerPhysicsPublicationStateTests
             default:
                 throw new ArgumentOutOfRangeException(nameof(mutation));
         }
+    }
+
+    private static void AddSyntheticIndoorCell(PhysicsDataCache cache, uint cellId)
+    {
+        var root = new CellBSPNode { Type = BSPNodeType.Leaf };
+        cache.RegisterCellStructForTest(cellId, new CellPhysics
+        {
+            WorldTransform = Matrix4x4.Identity,
+            InverseWorldTransform = Matrix4x4.Identity,
+            Resolved = new Dictionary<ushort, ResolvedPolygon>(),
+            Portals = [new PortalInfo(0, 0, 0)],
+            CellBSP = new CellBSPTree
+            {
+                Root = root,
+            },
+            FlatContainmentBsp = FlatCollisionAssetBuilder.FlattenCellContainmentBsp(root),
+            FlatPhysicsBsp = FlatCollisionAssetBuilder.FlattenPhysicsBsp(
+                null, new Dictionary<ushort, ResolvedPolygon>()),
+        });
+        cache.CellGraph.Add(new EnvCell(
+            cellId, Matrix4x4.Identity, Matrix4x4.Identity,
+            Vector3.Zero, Vector3.One, Array.Empty<CellPortal>(),
+            Array.Empty<uint>(), seenOutside: false, containmentBsp: null));
     }
 
     private static RuntimeCollisionGenerationCommit CommitPrepared(

--- a/tests/AcDream.Runtime.Tests/Physics/RuntimeSetPositionStateTests.cs
+++ b/tests/AcDream.Runtime.Tests/Physics/RuntimeSetPositionStateTests.cs
@@ -2353,6 +2353,119 @@ public sealed class RuntimeSetPositionStateTests
         Assert.Equal(0, final.DeferredSetPositionBucketCount);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SpawnReadyRecoveryRetainsOrderedSurvivorsWhenObserverStartsAdmission(bool unbound)
+    {
+        PhysicsEngine engine = FlatEngine(SourceLandblock, 0f);
+        using var lifetime = new RuntimeEntityObjectLifetime(engine);
+        RuntimeEntityRecord[] records = Enumerable.Range(0, 3)
+            .Select(index => CreateRecord(lifetime, 0x70001140u + (uint)index, 1))
+            .ToArray();
+        RuntimeCollisionAdmission? replacement = null;
+        var placed = new List<RuntimeEntityKey>();
+        var observer = new PlacementObserver(delta =>
+        {
+            if (delta.Placement.Kind != RuntimePlacementProjectionKind.Place)
+                return;
+            placed.Add(delta.Placement.Token.Entity);
+            Assert.True(lifetime.Physics.SetPosition.AcknowledgeProjection(
+                delta.Placement.Token));
+            if (replacement is null)
+                replacement = lifetime.Physics.BeginCollisionAdmission(DestinationLandblock);
+        });
+        using IDisposable subscription = lifetime.Events.SubscribePlacement(observer);
+
+        void CommitMissingCell()
+        {
+            RuntimeCollisionAdmission admission = lifetime.Physics
+                .BeginCollisionAdmission(DestinationLandblock);
+            using PreparedLandblockCollisionGeneration prepared = lifetime.Physics
+                .PrepareCollisionGeneration(admission);
+            lifetime.Physics.StageCollisionAssets(
+                admission, prepared, CollisionAssets(DestinationLandblock));
+            Assert.True(CommitPrepared(lifetime.Physics, admission, prepared).Committed);
+        }
+
+        if (!unbound)
+            CommitMissingCell();
+        foreach (RuntimeEntityRecord record in records)
+        {
+            _ = AttachBody(lifetime, record, SourceCell);
+            RuntimeSetPositionOutcome deferred = lifetime.Physics.SetPosition.Apply(
+                record,
+                record.PositionAuthorityVersion,
+                Command(Request(DestinationIndoorCell, new Vector3(10f, 12f, 7f))));
+            Assert.Equal(RuntimeSetPositionStatus.DeferredCell, deferred.Status);
+            Assert.True(lifetime.Physics.SetPosition.AcknowledgeProjection(deferred.Projection));
+        }
+        if (unbound)
+            CommitMissingCell();
+        Assert.Equal(unbound ? 1 : 0, lifetime.Physics.CaptureOwnership()
+            .UnboundDeferredSetPositionCellCount);
+
+        AddSyntheticCell(engine.DataCache!, DestinationIndoorCell);
+        Assert.Equal(3, lifetime.Physics.SetPosition
+            .TryRecoverUnboundDeferredWhenSpawnReady(DestinationIndoorCell));
+        Assert.NotNull(replacement);
+        Assert.Equal(new[] { records[0].Key!.Value }, placed);
+        Assert.True(lifetime.Physics.SetPosition.IsDeferred(records[1]));
+        Assert.True(lifetime.Physics.SetPosition.IsDeferred(records[2]));
+        Assert.Equal(1, lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+        Assert.Equal(0, lifetime.Physics.CaptureOwnership().UnboundDeferredSetPositionCellCount);
+        Assert.Equal(0, lifetime.Physics.SetPosition
+            .TryRecoverUnboundDeferredWhenSpawnReady(DestinationIndoorCell));
+
+        using PreparedLandblockCollisionGeneration ready = lifetime.Physics
+            .PrepareCollisionGeneration(replacement);
+        lifetime.Physics.StageCollisionAssets(
+            replacement, ready, CollisionAssets(DestinationLandblock));
+        AddSyntheticCell(ready.DataCache, DestinationIndoorCell);
+        Assert.True(CommitPrepared(lifetime.Physics, replacement, ready).Committed);
+        Assert.Equal(
+            new[] { records[1].Key!.Value, records[2].Key!.Value },
+            placed.Where(key => key != records[0].Key));
+        Assert.All(records, record => Assert.False(lifetime.Physics.SetPosition.IsDeferred(record)));
+        Assert.Equal(0, lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+        Assert.Equal(0, lifetime.Physics.CaptureOwnership().UnboundDeferredSetPositionCellCount);
+    }
+
+    [Fact]
+    public void SpawnReadyRecoveryKeepsUnacknowledgedWithdrawalIndexed()
+    {
+        PhysicsEngine engine = FlatEngine(SourceLandblock, 0f);
+        using var lifetime = new RuntimeEntityObjectLifetime(engine);
+        RuntimeCollisionAdmission admission = lifetime.Physics
+            .BeginCollisionAdmission(DestinationLandblock);
+        using (PreparedLandblockCollisionGeneration prepared = lifetime.Physics
+               .PrepareCollisionGeneration(admission))
+        {
+            lifetime.Physics.StageCollisionAssets(
+                admission, prepared, CollisionAssets(DestinationLandblock));
+            Assert.True(CommitPrepared(lifetime.Physics, admission, prepared).Committed);
+        }
+        RuntimeEntityRecord record = CreateRecord(lifetime, 0x70001144u, 1);
+        _ = AttachBody(lifetime, record, SourceCell);
+        var observer = new PlacementObserver();
+        using IDisposable subscription = lifetime.Events.SubscribePlacement(observer);
+        RuntimeSetPositionOutcome deferred = lifetime.Physics.SetPosition.Apply(
+            record, record.PositionAuthorityVersion,
+            Command(Request(DestinationIndoorCell, new Vector3(10f, 12f, 7f))));
+        Assert.Equal(RuntimeSetPositionStatus.DeferredCell, deferred.Status);
+        AddSyntheticCell(engine.DataCache!, DestinationIndoorCell);
+        Assert.Equal(1, lifetime.Physics.SetPosition
+            .TryRecoverUnboundDeferredWhenSpawnReady(DestinationIndoorCell));
+        Assert.Single(observer.Deltas);
+        Assert.True(lifetime.Physics.SetPosition.IsDeferred(record));
+        Assert.Equal(1, lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+
+        Assert.True(lifetime.Physics.SetPosition.AcknowledgeProjection(deferred.Projection));
+        Assert.Equal(RuntimePlacementProjectionKind.Place, observer.Deltas[^1].Placement.Kind);
+        Assert.False(lifetime.Physics.SetPosition.IsDeferred(record));
+        Assert.Equal(0, lifetime.Physics.CaptureOwnership().DeferredSetPositionBucketCount);
+    }
+
     [Fact]
     public void CollisionAdmissionSupersessionAndInvalidationPreserveDeferredSurvivorOrder()
     {

--- a/tests/AcDream.Runtime.Tests/Physics/RuntimeSetPositionStateTests.cs
+++ b/tests/AcDream.Runtime.Tests/Physics/RuntimeSetPositionStateTests.cs
@@ -2235,6 +2235,125 @@ public sealed class RuntimeSetPositionStateTests
     }
 
     [Fact]
+    public void CommittedGenerationWithoutExactIndoorCell_RecoversWhenSpawnBecomesReadyWithoutNewAdmission()
+    {
+        PhysicsEngine engine = FlatEngine(SourceLandblock, 0f);
+        using var lifetime = new RuntimeEntityObjectLifetime(engine);
+        RuntimeEntityRecord record = CreateRecord(lifetime, 0x70001134u, 1);
+        _ = AttachBody(lifetime, record, SourceCell);
+        var observer = new PlacementObserver();
+        using IDisposable subscription = lifetime.Events.SubscribePlacement(observer);
+        RuntimeSetPositionOutcome deferred = lifetime.Physics.SetPosition.Apply(
+            record,
+            record.PositionAuthorityVersion,
+            Command(Request(
+                DestinationIndoorCell,
+                new Vector3(10f, 12f, 7f))));
+        Assert.Equal(RuntimeSetPositionStatus.DeferredCell, deferred.Status);
+        Assert.True(lifetime.Physics.SetPosition.AcknowledgeProjection(
+            deferred.Projection));
+
+        RuntimeCollisionAdmission missing = lifetime.Physics
+            .BeginCollisionAdmission(DestinationLandblock);
+        using (PreparedLandblockCollisionGeneration prepared =
+               lifetime.Physics.PrepareCollisionGeneration(missing))
+        {
+            lifetime.Physics.StageCollisionAssets(
+                missing,
+                prepared,
+                CollisionAssets(DestinationLandblock));
+            Assert.True(CommitPrepared(
+                lifetime.Physics,
+                missing,
+                prepared).Committed);
+        }
+        Assert.Equal(1, lifetime.Physics.CaptureOwnership()
+            .UnboundDeferredSetPositionCellCount);
+        Assert.Single(observer.Deltas);
+
+        // Spawn EnvCell arrives on the live cache after commit, with no later
+        // collision admission — the login first-entry strand case.
+        Assert.NotNull(engine.DataCache);
+        AddSyntheticCell(engine.DataCache, DestinationIndoorCell);
+        Assert.Equal(
+            1,
+            lifetime.Physics.SetPosition.TryRecoverUnboundDeferredWhenSpawnReady(
+                DestinationIndoorCell));
+
+        RuntimePlacementProjectionSnapshot placed = observer.Deltas[^1].Placement;
+        Assert.Equal(RuntimePlacementProjectionKind.Place, placed.Kind);
+        Assert.Equal(DestinationIndoorCell, placed.Token.ExactCellId);
+        RuntimePhysicsOwnershipSnapshot final = lifetime.Physics.CaptureOwnership();
+        Assert.Equal(0, final.UnboundDeferredSetPositionCellCount);
+        Assert.Equal(0, final.DeferredSetPositionBucketCount);
+    }
+
+    [Fact]
+    public void ParkedOnExpectedAfterAuthority_RecoversWhenSpawnBecomesReadyWithoutNewAdmission()
+    {
+        // Indoor login race: landblock collision already at authority N, then
+        // set-position parks on Expected N+1 because the EnvCell is still
+        // missing. When the EnvCell arrives with no later admission, recover
+        // must rebind onto N — otherwise first-entry stays unpublished forever.
+        PhysicsEngine engine = FlatEngine(SourceLandblock, 0f);
+        using var lifetime = new RuntimeEntityObjectLifetime(engine);
+        RuntimeEntityRecord record = CreateRecord(lifetime, 0x70001135u, 1);
+        _ = AttachBody(lifetime, record, SourceCell);
+        var observer = new PlacementObserver();
+        using IDisposable subscription = lifetime.Events.SubscribePlacement(observer);
+
+        RuntimeCollisionAdmission prior = lifetime.Physics
+            .BeginCollisionAdmission(DestinationLandblock);
+        using (PreparedLandblockCollisionGeneration prepared =
+               lifetime.Physics.PrepareCollisionGeneration(prior))
+        {
+            lifetime.Physics.StageCollisionAssets(
+                prior,
+                prepared,
+                CollisionAssets(DestinationLandblock));
+            Assert.True(CommitPrepared(
+                lifetime.Physics,
+                prior,
+                prepared).Committed);
+        }
+        Assert.Equal(
+            1UL,
+            lifetime.Physics.CollisionGenerationAuthority(DestinationIndoorCell));
+        Assert.Equal(
+            2UL,
+            lifetime.Physics.ExpectedCollisionGeneration(DestinationIndoorCell));
+
+        RuntimeSetPositionOutcome deferred = lifetime.Physics.SetPosition.Apply(
+            record,
+            record.PositionAuthorityVersion,
+            Command(Request(
+                DestinationIndoorCell,
+                new Vector3(10f, 12f, 7f))));
+        Assert.Equal(RuntimeSetPositionStatus.DeferredCell, deferred.Status);
+        Assert.True(lifetime.Physics.SetPosition.AcknowledgeProjection(
+            deferred.Projection));
+        Assert.Equal(1, lifetime.Physics.CaptureOwnership()
+            .DeferredSetPositionBucketCount);
+        Assert.Equal(0, lifetime.Physics.CaptureOwnership()
+            .UnboundDeferredSetPositionCellCount);
+        Assert.Single(observer.Deltas);
+
+        Assert.NotNull(engine.DataCache);
+        AddSyntheticCell(engine.DataCache, DestinationIndoorCell);
+        Assert.Equal(
+            1,
+            lifetime.Physics.SetPosition.TryRecoverUnboundDeferredWhenSpawnReady(
+                DestinationIndoorCell));
+
+        RuntimePlacementProjectionSnapshot placed = observer.Deltas[^1].Placement;
+        Assert.Equal(RuntimePlacementProjectionKind.Place, placed.Kind);
+        Assert.Equal(DestinationIndoorCell, placed.Token.ExactCellId);
+        RuntimePhysicsOwnershipSnapshot final = lifetime.Physics.CaptureOwnership();
+        Assert.Equal(0, final.UnboundDeferredSetPositionCellCount);
+        Assert.Equal(0, final.DeferredSetPositionBucketCount);
+    }
+
+    [Fact]
     public void CollisionAdmissionSupersessionAndInvalidationPreserveDeferredSurvivorOrder()
     {
         PhysicsEngine engine = FlatEngine(SourceLandblock, 0f);


### PR DESCRIPTION
## What this changes
Indoor local-player first-entry can park dormant set-position on Expected generation N+1 after landblock authority is already N. When the EnvCell becomes ready with no later admission, the op never wakes, so the movement controller stays unpublished and login never leaves portal space.

This recovers stranded deferred ops onto the committed authority when the spawn cell is ready (including after admission close), and parks immediately-ready when authority + spawn + admissibility are already satisfied.

## Original behavior
Retail / ACE clients finish first-entry once the destination cell is available. OpenAC was waiting for a future collision generation that never arrives for this indoor login race.

## Checklist
- [x] `dotnet build` / targeted Runtime tests green locally
- [x] The portable test filter subset for these tests passes locally
- [x] One topic per PR
- [x] No code copied from ACEmulator, ACViewer, or holtburger
- [x] No comments describing the original client's internals

## Test plan
- [ ] Runtime tests: `ParkedOnExpectedAfterAuthority_RecoversWhenSpawnBecomesReadyWithoutNewAdmission`, unbound recover, deferred commit suite
- [ ] Live ACE indoor spawn (e.g. DreamWeave starter dungeon): first-entry publishes after landblock ready

## Notes
Paired with a follow-up App PR for login presentation / `LoginComplete` (Hidden / purple-bubble race). Merge this first.

Made with [Cursor](https://cursor.com)