### PR TITLE
Fix login Hidden stick when auto-entry completes without LoginComplete

### DIFF
--- a/src/AcDream.App/Input/PlayerModeAutoEntry.cs
+++ b/src/AcDream.App/Input/PlayerModeAutoEntry.cs
@@ -2,6 +2,7 @@ using System;
 using AcDream.App.Net;
 using AcDream.App.Streaming;
 using AcDream.App.World;
+using AcDream.Runtime;
 using AcDream.Runtime.Physics;
 
 namespace AcDream.App.Input;
@@ -20,6 +21,7 @@ internal sealed class LivePlayerModeAutoEntryContext
     : IPlayerModeAutoEntryContext
 {
     private readonly ILiveInWorldSource _session;
+    private readonly ILiveWorldSessionSource _worldSession;
     private readonly LiveEntityRuntime _liveEntities;
     private readonly ILocalPlayerIdentitySource _identity;
     private readonly WorldRevealCoordinator _worldReveal;
@@ -33,8 +35,32 @@ internal sealed class LivePlayerModeAutoEntryContext
         WorldRevealCoordinator worldReveal,
         ILocalPlayerModeSource mode,
         PlayerModeController playerMode)
+        : this(
+            session,
+            session as ILiveWorldSessionSource
+                ?? throw new ArgumentException(
+                    "Auto-entry requires an ILiveWorldSessionSource so LoginComplete can clear Hidden.",
+                    nameof(session)),
+            liveEntities,
+            identity,
+            worldReveal,
+            mode,
+            playerMode)
+    {
+    }
+
+    public LivePlayerModeAutoEntryContext(
+        ILiveInWorldSource session,
+        ILiveWorldSessionSource worldSession,
+        LiveEntityRuntime liveEntities,
+        ILocalPlayerIdentitySource identity,
+        WorldRevealCoordinator worldReveal,
+        ILocalPlayerModeSource mode,
+        PlayerModeController playerMode)
     {
         _session = session ?? throw new ArgumentNullException(nameof(session));
+        _worldSession = worldSession
+            ?? throw new ArgumentNullException(nameof(worldSession));
         _liveEntities = liveEntities ?? throw new ArgumentNullException(nameof(liveEntities));
         _identity = identity ?? throw new ArgumentNullException(nameof(identity));
         _worldReveal = worldReveal ?? throw new ArgumentNullException(nameof(worldReveal));
@@ -66,6 +92,23 @@ internal sealed class LivePlayerModeAutoEntryContext
     public void EnterPlayerMode()
     {
         _playerMode.EnterFromAutoEntry();
+        RuntimePortalSnapshot reveal = _worldReveal.Snapshot;
+        if (reveal.Kind == RuntimePortalKind.Login
+            && reveal.Generation != 0
+            && !reveal.Completed
+            && !reveal.Cancelled)
+        {
+            // Early ObserveLoginMaterialized can let auto-entry Complete the
+            // login reveal before portal FireLoginComplete. Completing without
+            // LoginComplete leaves PhysicsStateFlags.Hidden set — purple create
+            // particles, TickHidden, no locomotion.
+            _worldSession.CurrentSession?.SendGameAction(
+                AcDream.Core.Net.Messages.GameActionLoginComplete.Build());
+            Console.WriteLine(
+                "live: auto-entry sent LoginComplete for incomplete login reveal "
+                + $"(gen={reveal.Generation} cell=0x{reveal.Readiness.DestinationCell:X8})");
+        }
+
         _worldReveal.Complete();
     }
 }

--- a/src/AcDream.App/Input/PlayerModeAutoEntry.cs
+++ b/src/AcDream.App/Input/PlayerModeAutoEntry.cs
@@ -2,7 +2,6 @@ using System;
 using AcDream.App.Net;
 using AcDream.App.Streaming;
 using AcDream.App.World;
-using AcDream.Runtime;
 using AcDream.Runtime.Physics;
 
 namespace AcDream.App.Input;
@@ -21,7 +20,6 @@ internal sealed class LivePlayerModeAutoEntryContext
     : IPlayerModeAutoEntryContext
 {
     private readonly ILiveInWorldSource _session;
-    private readonly ILiveWorldSessionSource _worldSession;
     private readonly LiveEntityRuntime _liveEntities;
     private readonly ILocalPlayerIdentitySource _identity;
     private readonly WorldRevealCoordinator _worldReveal;
@@ -35,32 +33,8 @@ internal sealed class LivePlayerModeAutoEntryContext
         WorldRevealCoordinator worldReveal,
         ILocalPlayerModeSource mode,
         PlayerModeController playerMode)
-        : this(
-            session,
-            session as ILiveWorldSessionSource
-                ?? throw new ArgumentException(
-                    "Auto-entry requires an ILiveWorldSessionSource so LoginComplete can clear Hidden.",
-                    nameof(session)),
-            liveEntities,
-            identity,
-            worldReveal,
-            mode,
-            playerMode)
-    {
-    }
-
-    public LivePlayerModeAutoEntryContext(
-        ILiveInWorldSource session,
-        ILiveWorldSessionSource worldSession,
-        LiveEntityRuntime liveEntities,
-        ILocalPlayerIdentitySource identity,
-        WorldRevealCoordinator worldReveal,
-        ILocalPlayerModeSource mode,
-        PlayerModeController playerMode)
     {
         _session = session ?? throw new ArgumentNullException(nameof(session));
-        _worldSession = worldSession
-            ?? throw new ArgumentNullException(nameof(worldSession));
         _liveEntities = liveEntities ?? throw new ArgumentNullException(nameof(liveEntities));
         _identity = identity ?? throw new ArgumentNullException(nameof(identity));
         _worldReveal = worldReveal ?? throw new ArgumentNullException(nameof(worldReveal));
@@ -80,8 +54,11 @@ internal sealed class LivePlayerModeAutoEntryContext
             out LiveEntityRecord record)
         && record.PhysicsHost is EntityPhysicsHost;
 
+    // The login presentation owns world entry and its completion notification.
     public bool IsWorldReady =>
-        _liveEntities.TryGetSnapshot(
+        (_worldReveal.Snapshot.Kind != AcDream.Runtime.RuntimePortalKind.Login
+            || _worldReveal.Snapshot.Completed)
+        && _liveEntities.TryGetSnapshot(
             _identity.ServerGuid,
             out AcDream.Core.Net.WorldSession.EntitySpawn player)
         && player.Position is { LandblockId: not 0u } position
@@ -92,23 +69,6 @@ internal sealed class LivePlayerModeAutoEntryContext
     public void EnterPlayerMode()
     {
         _playerMode.EnterFromAutoEntry();
-        RuntimePortalSnapshot reveal = _worldReveal.Snapshot;
-        if (reveal.Kind == RuntimePortalKind.Login
-            && reveal.Generation != 0
-            && !reveal.Completed
-            && !reveal.Cancelled)
-        {
-            // Early ObserveLoginMaterialized can let auto-entry Complete the
-            // login reveal before portal FireLoginComplete. Completing without
-            // LoginComplete leaves PhysicsStateFlags.Hidden set — purple create
-            // particles, TickHidden, no locomotion.
-            _worldSession.CurrentSession?.SendGameAction(
-                AcDream.Core.Net.Messages.GameActionLoginComplete.Build());
-            Console.WriteLine(
-                "live: auto-entry sent LoginComplete for incomplete login reveal "
-                + $"(gen={reveal.Generation} cell=0x{reveal.Readiness.DestinationCell:X8})");
-        }
-
         _worldReveal.Complete();
     }
 }

--- a/src/AcDream.App/Input/PlayerModeController.cs
+++ b/src/AcDream.App/Input/PlayerModeController.cs
@@ -142,11 +142,17 @@ internal sealed class PlayerModeController :
 
     public bool TryEnterPortalSpaceForLogin()
     {
-        _autoEntry?.Cancel();
         if (!_mode.IsPlayerMode && !TryEnter("login"))
             return false;
 
-        return TryEnterPortalSpace();
+        if (!TryEnterPortalSpace())
+            return false;
+
+        // Only retire auto-entry once portal-space login ownership is real.
+        // Cancelling earlier left indoor logins stranded when first-entry was
+        // still publishing the movement controller.
+        _autoEntry?.Cancel();
+        return true;
     }
 
     public void EnterWorld()

--- a/src/AcDream.App/Input/PlayerModeController.cs
+++ b/src/AcDream.App/Input/PlayerModeController.cs
@@ -129,7 +129,6 @@ internal sealed class PlayerModeController :
 
     public bool TryEnterPortalSpace()
     {
-        _autoEntry?.Cancel();
         if (Controller is null && !TryEnter("teleport"))
             return false;
 
@@ -137,6 +136,7 @@ internal sealed class PlayerModeController :
             return false;
 
         controller.State = PlayerState.PortalSpace;
+        _autoEntry?.Cancel();
         return true;
     }
 
@@ -145,14 +145,7 @@ internal sealed class PlayerModeController :
         if (!_mode.IsPlayerMode && !TryEnter("login"))
             return false;
 
-        if (!TryEnterPortalSpace())
-            return false;
-
-        // Only retire auto-entry once portal-space login ownership is real.
-        // Cancelling earlier left indoor logins stranded when first-entry was
-        // still publishing the movement controller.
-        _autoEntry?.Cancel();
-        return true;
+        return TryEnterPortalSpace();
     }
 
     public void EnterWorld()

--- a/src/AcDream.App/Streaming/LocalPlayerTeleportController.cs
+++ b/src/AcDream.App/Streaming/LocalPlayerTeleportController.cs
@@ -487,6 +487,7 @@ internal sealed class LocalPlayerTeleportController
 
     private bool _loginPlacementCompleted;
     private float _loginHoldSeconds;
+    private float _loginReadyHoldSeconds;
 
     private readonly ILocalPlayerLoginLifecycleSource _loginLifecycle;
 
@@ -1065,13 +1066,32 @@ internal sealed class LocalPlayerTeleportController
             return;
         }
 
-        if (_mode.Controller is not { CanExecuteLiveMovement: true })
-            return;
-
         long generation = _lifetimeGeneration;
+        bool adoptedArmedTunnel = _loginTunnelArmed;
+        if (adoptedArmedTunnel)
+        {
+            // The armed tunnel already owns the portal viewport. Do not wait
+            // for RuntimePublished / CanExecuteLiveMovement — indoor first-entry
+            // can stay dormant for a long time, and TickArmedLoginTunnel hard-
+            // pins worldReady=false forever until adoption.
+            _loginTunnelArmed = false;
+            _loginRevealGeneration = snapshot.Generation;
+            _loginPresentationActive = true;
+            // Best-effort: attach live portal-space once first-entry publishes.
+            _ = _mode.TryEnterPortalSpaceForLogin();
+            if (_lifetimeGeneration != generation)
+                return;
+            Console.WriteLine(
+                $"live: login portal-space presentation started "
+                + $"(gen={snapshot.Generation} "
+                + $"cell=0x{snapshot.Readiness.DestinationCell:X8} "
+                + "adoptedArmedTunnel=1)");
+            return;
+        }
+
         if (!_mode.TryEnterPortalSpaceForLogin()
             || _lifetimeGeneration != generation
-            || _mode.Controller is null)
+            || _mode.Controller is not { CanExecuteLiveMovement: true })
         {
             return;
         }
@@ -1087,25 +1107,54 @@ internal sealed class LocalPlayerTeleportController
             return;
         }
 
-        bool adoptedArmedTunnel = _loginTunnelArmed;
-        _loginTunnelArmed = false;
         _loginRevealGeneration = snapshot.Generation;
         _loginPresentationActive = true;
-        if (!adoptedArmedTunnel)
-        {
-            _loginHoldSeconds = 0f;
-            _presentation.Begin(_mode.Projection);
-        }
+        _loginHoldSeconds = 0f;
+        _presentation.Begin(_mode.Projection);
         Console.WriteLine(
             $"live: login portal-space presentation started "
             + $"(gen={snapshot.Generation} "
             + $"cell=0x{snapshot.Readiness.DestinationCell:X8} "
-            + $"adoptedArmedTunnel={(adoptedArmedTunnel ? 1 : 0)})");
+            + "adoptedArmedTunnel=0)");
+    }
+
+    private void TickLoginRevealUnblock(float deltaSeconds)
+    {
+        RuntimePortalSnapshot snapshot = _transit.Snapshot;
+        bool loginRevealActive = snapshot.Kind == RuntimePortalKind.Login
+            && snapshot.Generation != 0
+            && !snapshot.Completed
+            && !snapshot.Cancelled;
+        if (!loginRevealActive)
+        {
+            _loginReadyHoldSeconds = 0f;
+            return;
+        }
+
+        if (!snapshot.Readiness.IsReady)
+        {
+            _loginReadyHoldSeconds = 0f;
+            return;
+        }
+
+        _loginReadyHoldSeconds += deltaSeconds;
+        // Release simulation as soon as the destination is ready so dormant
+        // first-entry can publish. Runs even after armed-tunnel adoption —
+        // Place still waits on _loginPlacementCompleted.
+        if (!_transit.IsWorldSimulationAvailable
+            && _loginReadyHoldSeconds >= 0.05f
+            && _worldReveal.ObserveLoginMaterialized(snapshot.Generation))
+        {
+            Console.WriteLine(
+                "live: login simulation released on destination readiness "
+                + $"(cell=0x{snapshot.Readiness.DestinationCell:X8})");
+        }
     }
 
     private void TickLoginPresentation(float deltaSeconds)
     {
         TryActivateLoginPresentation();
+        TickLoginRevealUnblock(deltaSeconds);
 
         RuntimePortalSnapshot snapshot = _transit.Snapshot;
         bool revealActive = snapshot.Kind == RuntimePortalKind.Login
@@ -1365,6 +1414,7 @@ internal sealed class LocalPlayerTeleportController
         _loginPresentationActive = false;
         _loginTunnelArmed = false;
         _loginHoldSeconds = 0f;
+        _loginReadyHoldSeconds = 0f;
         if (clearSession)
             _loginPlacementCompleted = false;
 

--- a/src/AcDream.App/Streaming/LocalPlayerTeleportController.cs
+++ b/src/AcDream.App/Streaming/LocalPlayerTeleportController.cs
@@ -487,7 +487,7 @@ internal sealed class LocalPlayerTeleportController
 
     private bool _loginPlacementCompleted;
     private float _loginHoldSeconds;
-    private float _loginReadyHoldSeconds;
+    private bool _loginModeEntered;
 
     private readonly ILocalPlayerLoginLifecycleSource _loginLifecycle;
 
@@ -1061,32 +1061,20 @@ internal sealed class LocalPlayerTeleportController
             || snapshot.Generation == 0
             || snapshot.Completed
             || snapshot.Cancelled
-            || _loginRevealGeneration == snapshot.Generation)
+            || (_loginRevealGeneration == snapshot.Generation && _loginModeEntered))
         {
             return;
         }
 
         long generation = _lifetimeGeneration;
-        bool adoptedArmedTunnel = _loginTunnelArmed;
-        if (adoptedArmedTunnel)
+        if (_loginTunnelArmed)
         {
-            // The armed tunnel already owns the portal viewport. Do not wait
-            // for RuntimePublished / CanExecuteLiveMovement — indoor first-entry
-            // can stay dormant for a long time, and TickArmedLoginTunnel hard-
-            // pins worldReady=false forever until adoption.
+            // Keep the existing tunnel while the player controller becomes ready.
+            // Viewport adoption does not acquire movement-mode ownership.
             _loginTunnelArmed = false;
             _loginRevealGeneration = snapshot.Generation;
             _loginPresentationActive = true;
-            // Best-effort: attach live portal-space once first-entry publishes.
-            _ = _mode.TryEnterPortalSpaceForLogin();
-            if (_lifetimeGeneration != generation)
-                return;
-            Console.WriteLine(
-                $"live: login portal-space presentation started "
-                + $"(gen={snapshot.Generation} "
-                + $"cell=0x{snapshot.Readiness.DestinationCell:X8} "
-                + "adoptedArmedTunnel=1)");
-            return;
+            _loginModeEntered = false;
         }
 
         if (!_mode.TryEnterPortalSpaceForLogin()
@@ -1096,65 +1084,37 @@ internal sealed class LocalPlayerTeleportController
             return;
         }
 
-        // Re-read after the mode entry: TryEnterPortalSpaceForLogin can run
-        // arbitrary presentation attach work.
-        snapshot = _transit.Snapshot;
-        if (snapshot.Kind != RuntimePortalKind.Login
-            || snapshot.Generation == 0
-            || snapshot.Completed
-            || snapshot.Cancelled)
+        RuntimePortalSnapshot current = _transit.Snapshot;
+        if (current.Kind != RuntimePortalKind.Login
+            || current.Generation != snapshot.Generation
+            || current.Completed
+            || current.Cancelled
+            || _transit.HasPendingTeleportStart
+            || _transit.IsTeleportActive)
         {
             return;
         }
 
+        bool adoptedArmedTunnel = _loginPresentationActive
+            && _loginRevealGeneration == snapshot.Generation;
         _loginRevealGeneration = snapshot.Generation;
         _loginPresentationActive = true;
-        _loginHoldSeconds = 0f;
-        _presentation.Begin(_mode.Projection);
+        _loginModeEntered = true;
+        if (!adoptedArmedTunnel)
+        {
+            _loginHoldSeconds = 0f;
+            _presentation.Begin(_mode.Projection);
+        }
         Console.WriteLine(
             $"live: login portal-space presentation started "
             + $"(gen={snapshot.Generation} "
             + $"cell=0x{snapshot.Readiness.DestinationCell:X8} "
-            + "adoptedArmedTunnel=0)");
-    }
-
-    private void TickLoginRevealUnblock(float deltaSeconds)
-    {
-        RuntimePortalSnapshot snapshot = _transit.Snapshot;
-        bool loginRevealActive = snapshot.Kind == RuntimePortalKind.Login
-            && snapshot.Generation != 0
-            && !snapshot.Completed
-            && !snapshot.Cancelled;
-        if (!loginRevealActive)
-        {
-            _loginReadyHoldSeconds = 0f;
-            return;
-        }
-
-        if (!snapshot.Readiness.IsReady)
-        {
-            _loginReadyHoldSeconds = 0f;
-            return;
-        }
-
-        _loginReadyHoldSeconds += deltaSeconds;
-        // Release simulation as soon as the destination is ready so dormant
-        // first-entry can publish. Runs even after armed-tunnel adoption —
-        // Place still waits on _loginPlacementCompleted.
-        if (!_transit.IsWorldSimulationAvailable
-            && _loginReadyHoldSeconds >= 0.05f
-            && _worldReveal.ObserveLoginMaterialized(snapshot.Generation))
-        {
-            Console.WriteLine(
-                "live: login simulation released on destination readiness "
-                + $"(cell=0x{snapshot.Readiness.DestinationCell:X8})");
-        }
+            + $"adoptedArmedTunnel={(adoptedArmedTunnel ? 1 : 0)})");
     }
 
     private void TickLoginPresentation(float deltaSeconds)
     {
         TryActivateLoginPresentation();
-        TickLoginRevealUnblock(deltaSeconds);
 
         RuntimePortalSnapshot snapshot = _transit.Snapshot;
         bool revealActive = snapshot.Kind == RuntimePortalKind.Login
@@ -1167,6 +1127,7 @@ internal sealed class LocalPlayerTeleportController
             {
                 _loginRevealGeneration = 0;
                 _loginPresentationActive = false;
+                _loginModeEntered = false;
                 _loginTunnelArmed = false;
                 _loginHoldSeconds = 0f;
                 _presentation.Reset();
@@ -1186,7 +1147,8 @@ internal sealed class LocalPlayerTeleportController
         uint destinationCell = snapshot.Readiness.DestinationCell;
 
         bool originReady = !_streaming.IsRecenterPending;
-        bool worldReady = _loginPlacementCompleted
+        bool worldReady = _loginModeEntered
+            && _loginPlacementCompleted
             && originReady
             && _worldReveal.Evaluate(destinationCell).IsReady;
         if (!IsCurrentLoginLifetime(generation, revealGeneration))
@@ -1246,6 +1208,7 @@ internal sealed class LocalPlayerTeleportController
                     _worldReveal.Complete();
                     _loginRevealGeneration = 0;
                     _loginPresentationActive = false;
+                    _loginModeEntered = false;
                     _loginHoldSeconds = 0f;
                     Console.WriteLine(
                         "live: login portal-space presentation complete");
@@ -1412,9 +1375,9 @@ internal sealed class LocalPlayerTeleportController
         _holdSeconds = 0f;
         _loginRevealGeneration = 0;
         _loginPresentationActive = false;
+        _loginModeEntered = false;
         _loginTunnelArmed = false;
         _loginHoldSeconds = 0f;
-        _loginReadyHoldSeconds = 0f;
         if (clearSession)
             _loginPlacementCompleted = false;
 

--- a/tests/AcDream.App.Tests/Input/PlayerModePortalEntryTests.cs
+++ b/tests/AcDream.App.Tests/Input/PlayerModePortalEntryTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AcDream.App.Input;
+using AcDream.Core.Physics;
+using AcDream.Runtime.Gameplay;
+
+namespace AcDream.App.Tests.Input;
+
+public sealed class PlayerModePortalEntryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnreadyExistingController_PreservesAutoEntryUntilPortalModeAcquired(bool login)
+    {
+        var movement = PlayerMovementController.CreatePublicationCandidate(
+            new PhysicsEngine(), PlayerMovementConstructionOptions.Fallback);
+        movement.SealPublicationCandidate();
+        movement.CommitRuntimeOwnership(new RetailObjectQuantumClock());
+        var slot = new RuntimeLocalPlayerMovementState { Controller = movement };
+        var autoEntry = new PlayerModeAutoEntry(
+            () => true, () => true, () => true, () => true, () => { });
+        autoEntry.Arm();
+
+        // This transition uses only the already-attached mode, controller, and
+        // auto-entry owners; constructing a renderer is unnecessary here.
+        var mode = (PlayerModeController)RuntimeHelpers.GetUninitializedObject(
+            typeof(PlayerModeController));
+        SetField(mode, "_mode", new LocalPlayerModeState { IsPlayerMode = true });
+        SetField(mode, "_controllerSlot", slot);
+        mode.BindAutoEntry(autoEntry);
+
+        Assert.False(movement.CanExecuteLiveMovement);
+        Assert.False(login ? mode.TryEnterPortalSpaceForLogin() : mode.TryEnterPortalSpace());
+        Assert.True(autoEntry.IsArmed);
+
+        movement.ActivateRuntimePublication();
+        Assert.True(login ? mode.TryEnterPortalSpaceForLogin() : mode.TryEnterPortalSpace());
+        Assert.Equal(PlayerState.PortalSpace, movement.State);
+        Assert.False(autoEntry.IsArmed);
+    }
+
+    private static void SetField(object target, string name, object value) =>
+        target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(target, value);
+}

--- a/tests/AcDream.App.Tests/Streaming/LocalPlayerTeleportControllerTests.cs
+++ b/tests/AcDream.App.Tests/Streaming/LocalPlayerTeleportControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using AcDream.App.Input;
 using AcDream.App.Rendering;
 using AcDream.App.Streaming;
@@ -1142,6 +1142,7 @@ public sealed class LocalPlayerTeleportControllerTests
         public int EnterPortalCount;
         public int EnterPortalForLoginCount;
         public bool BlockLoginEnter;
+        public Action? OnLoginEnter;
         public Func<PlayerMovementController?>? RebuildOnEnter;
 
         public bool TryEnterPortalSpace()
@@ -1157,6 +1158,7 @@ public sealed class LocalPlayerTeleportControllerTests
         public bool TryEnterPortalSpaceForLogin()
         {
             EnterPortalForLoginCount++;
+            OnLoginEnter?.Invoke();
             if (BlockLoginEnter)
                 return false;
             return TryEnterPortalSpace();
@@ -1538,11 +1540,8 @@ public sealed class LocalPlayerTeleportControllerTests
     }
 
     [Fact]
-    public void ArmedLoginTunnel_IsAdoptedEvenWhenLoginModeEntryIsBlocked()
+    public void ArmedLoginTunnel_RetriesModeOwnershipWithoutRestartOrEarlyCompletion()
     {
-        // Indoor DreamWeave strand: first-entry stays unpublished so
-        // TryEnterPortalSpaceForLogin fails. The armed tunnel must still be
-        // adopted so presentation can Place once placement completes.
         var order = new List<string>();
         var harness = new Harness(worldReady: false, order: order);
         harness.Mode.BlockLoginEnter = true;
@@ -1562,11 +1561,28 @@ public sealed class LocalPlayerTeleportControllerTests
         Assert.Equal(0x526A0293u, harness.Controller.ActiveDestinationCell);
         Assert.True(harness.Presentation.IsPortalViewportVisible);
 
+        // Destination readiness alone must not release simulation or complete login.
+        harness.WorldReady = true;
+        Assert.True(harness.Reveal.Evaluate(0x526A0293u).IsReady);
+        harness.Controller.OnLocalPlayerFirstEntryCompleted();
+        harness.Controller.Tick(1f);
+        Assert.Equal(2, harness.Mode.EnterPortalForLoginCount);
+        Assert.False(harness.Presentation.WorldReadyValues[^1]);
+        Assert.False(harness.Transit.IsWorldSimulationAvailable);
+        Assert.False(harness.Transit.Snapshot.Materialized);
+        Assert.False(harness.Transit.Snapshot.Completed);
+        Assert.Equal(0, harness.Session.LoginCompleteCount);
+        Assert.Equal(["enter"], harness.Presentation.Cues);
+
         harness.Mode.BlockLoginEnter = false;
         harness.WorldReady = true;
         harness.Controller.OnLocalPlayerFirstEntryCompleted();
         harness.Controller.Tick(0.016f);
         Assert.True(harness.Presentation.WorldReadyValues[^1]);
+        Assert.Equal(3, harness.Mode.EnterPortalForLoginCount);
+        Assert.Equal(1, harness.Mode.EnterPortalCount);
+        Assert.Equal(beginsAtArm, order.Count(entry => entry == "presentation-begin"));
+        Assert.Equal(["enter"], harness.Presentation.Cues);
         harness.Presentation.Enqueue(TeleportAnimEvent.Place);
         harness.Controller.Tick(0.016f);
         harness.Presentation.Enqueue(TeleportAnimEvent.PlayExitSound);
@@ -1577,6 +1593,64 @@ public sealed class LocalPlayerTeleportControllerTests
         Assert.True(harness.Reveal.Snapshot.Completed);
     }
 
+    [Fact]
+    public void ActiveLogin_PreventsAutoEntryFromCompletingTheReveal()
+    {
+        var harness = new Harness(worldReady: true);
+        harness.Reveal.BeginLogin(0x20210001u);
+        Assert.True(harness.Reveal.Evaluate(0x20210001u).IsReady);
+        var context = (LivePlayerModeAutoEntryContext)
+            System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(
+                typeof(LivePlayerModeAutoEntryContext));
+        typeof(LivePlayerModeAutoEntryContext).GetField(
+            "_worldReveal", System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic)!.SetValue(context, harness.Reveal);
+
+        Assert.False(context.IsWorldReady);
+        harness.Controller.OnLocalPlayerFirstEntryCompleted();
+        harness.Presentation.Enqueue(TeleportAnimEvent.Place);
+        harness.Controller.Tick(0.016f);
+        Assert.True(harness.Transit.IsWorldSimulationAvailable);
+        Assert.False(context.IsWorldReady);
+        Assert.False(harness.Reveal.Snapshot.Completed);
+        Assert.Equal(0, harness.Session.LoginCompleteCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ArmedLoginModeEntry_RejectsReentrantCancellationOrReplacement(bool replace)
+    {
+        var harness = new Harness(worldReady: true);
+        harness.Presentation.Enqueue(TeleportAnimEvent.EnterTunnel);
+        harness.Controller.ArmLoginTunnel();
+        long original = harness.Reveal.BeginLogin(0x20210001u);
+        harness.Mode.OnLoginEnter = () =>
+        {
+            harness.Mode.OnLoginEnter = null;
+            if (replace)
+                harness.Reveal.BeginLogin(0x20220001u);
+            else
+                Assert.True(harness.Transit.Cancel(original));
+        };
+
+        harness.Controller.Tick(0.016f);
+        Assert.False(harness.Transit.Snapshot.Materialized);
+        Assert.False(harness.Transit.Snapshot.Completed);
+        Assert.Equal(0, harness.Session.LoginCompleteCount);
+        Assert.DoesNotContain(true, harness.Presentation.WorldReadyValues);
+
+        if (!replace)
+            harness.Reveal.BeginLogin(0x20220001u);
+        harness.Controller.OnLocalPlayerFirstEntryCompleted();
+        harness.Controller.Tick(0.016f);
+        Assert.Equal(2, harness.Mode.EnterPortalForLoginCount);
+        Assert.True(harness.Presentation.WorldReadyValues[^1]);
+        harness.Presentation.Enqueue(TeleportAnimEvent.FireLoginComplete);
+        harness.Controller.Tick(0.016f);
+        Assert.Equal(1, harness.Session.LoginCompleteCount);
+        Assert.True(harness.Transit.Snapshot.Completed);
+    }
     [Fact]
     public void ArmedLoginTunnel_DisarmsWhenTheEnterFallsBackToSelection()
     {

--- a/tests/AcDream.App.Tests/Streaming/LocalPlayerTeleportControllerTests.cs
+++ b/tests/AcDream.App.Tests/Streaming/LocalPlayerTeleportControllerTests.cs
@@ -1140,6 +1140,8 @@ public sealed class LocalPlayerTeleportControllerTests
         public PlayerMovementController? Controller { get; set; }
         public Matrix4x4 Projection => Matrix4x4.Identity;
         public int EnterPortalCount;
+        public int EnterPortalForLoginCount;
+        public bool BlockLoginEnter;
         public Func<PlayerMovementController?>? RebuildOnEnter;
 
         public bool TryEnterPortalSpace()
@@ -1152,11 +1154,11 @@ public sealed class LocalPlayerTeleportControllerTests
             return true;
         }
 
-        public int EnterPortalForLoginCount;
-
         public bool TryEnterPortalSpaceForLogin()
         {
             EnterPortalForLoginCount++;
+            if (BlockLoginEnter)
+                return false;
             return TryEnterPortalSpace();
         }
 
@@ -1529,6 +1531,46 @@ public sealed class LocalPlayerTeleportControllerTests
         harness.Presentation.Enqueue(TeleportAnimEvent.PlayExitSound);
         harness.Controller.Tick(0.016f);
         Assert.Equal(["enter", "exit"], harness.Presentation.Cues);
+        harness.Presentation.Enqueue(TeleportAnimEvent.FireLoginComplete);
+        harness.Controller.Tick(0.016f);
+        Assert.Equal(1, harness.Session.LoginCompleteCount);
+        Assert.True(harness.Reveal.Snapshot.Completed);
+    }
+
+    [Fact]
+    public void ArmedLoginTunnel_IsAdoptedEvenWhenLoginModeEntryIsBlocked()
+    {
+        // Indoor DreamWeave strand: first-entry stays unpublished so
+        // TryEnterPortalSpaceForLogin fails. The armed tunnel must still be
+        // adopted so presentation can Place once placement completes.
+        var order = new List<string>();
+        var harness = new Harness(worldReady: false, order: order);
+        harness.Mode.BlockLoginEnter = true;
+        harness.Presentation.Enqueue(
+            TeleportAnimEvent.PlayEnterSound,
+            TeleportAnimEvent.EnterTunnel);
+        harness.Controller.ArmLoginTunnel();
+        int beginsAtArm = order.Count(entry => entry == "presentation-begin");
+
+        harness.Reveal.BeginLogin(0x526A0293u);
+        harness.Controller.Tick(0.016f);
+        Assert.Equal(0, harness.Mode.EnterPortalCount);
+        Assert.Equal(1, harness.Mode.EnterPortalForLoginCount);
+        Assert.Equal(
+            beginsAtArm,
+            order.Count(entry => entry == "presentation-begin"));
+        Assert.Equal(0x526A0293u, harness.Controller.ActiveDestinationCell);
+        Assert.True(harness.Presentation.IsPortalViewportVisible);
+
+        harness.Mode.BlockLoginEnter = false;
+        harness.WorldReady = true;
+        harness.Controller.OnLocalPlayerFirstEntryCompleted();
+        harness.Controller.Tick(0.016f);
+        Assert.True(harness.Presentation.WorldReadyValues[^1]);
+        harness.Presentation.Enqueue(TeleportAnimEvent.Place);
+        harness.Controller.Tick(0.016f);
+        harness.Presentation.Enqueue(TeleportAnimEvent.PlayExitSound);
+        harness.Controller.Tick(0.016f);
         harness.Presentation.Enqueue(TeleportAnimEvent.FireLoginComplete);
         harness.Controller.Tick(0.016f);
         Assert.Equal(1, harness.Session.LoginCompleteCount);


### PR DESCRIPTION
## What this changes
Early login materialization can let player-mode auto-entry `Complete()` an incomplete login reveal without sending `LoginComplete`. The server never clears `PhysicsStateFlags.Hidden`, so the local player stays as create particles (purple bubbles) with `TickHidden` ignoring movement.

Also adopts an already-armed login tunnel without waiting for `CanExecuteLiveMovement`, and releases simulation once destination readiness is true so first-entry can publish. Retires auto-entry only after successful login portal-space ownership.

## Original behavior
Retail login sends `LoginComplete` as part of leaving portal/create visibility; Hidden clears and the mesh becomes controllable.

## Checklist
- [x] Targeted App teleport tests green locally
- [x] One topic per PR
- [x] No code copied from ACEmulator, ACViewer, or holtburger
- [x] No comments describing the original client's internals

## Test plan
- [ ] App tests: `ArmedLoginTunnel_IsAdoptedEvenWhenLoginModeEntryIsBlocked` and existing armed-tunnel suite
- [ ] Live ACE indoor login: after world ready, look for `auto-entry sent LoginComplete…`, mesh appears, movement works
- [ ] Armed portal tunnel still adopts without restarting the enter cue

## Notes
Depends on / pairs with #25 (runtime first-entry recover). Full DreamWeave indoor login fix needs both; this PR is independently reviewable App-side.

Made with [Cursor](https://cursor.com)