### PR TITLE
Soft-refresh skills list instead of rebuilding on every sheet update

### DIFF
--- a/src/AcDream.App/UI/Layout/CharacterStatController.cs
+++ b/src/AcDream.App/UI/Layout/CharacterStatController.cs
@@ -421,11 +421,23 @@ public static class CharacterStatController
                 return;
             }
 
+            CharacterSheet sheet = data();
             CharacterSkill? selectedSkill =
                 skillSel[0] >= 0 && skillSel[0] < currentSkillRows.Count
-                    ? currentSkillRows[skillSel[0]].Skill
+                    ? FindSkill(sheet, currentSkillRows[skillSel[0]].Skill.Id)
                     : null;
-            RefreshSkillRaiseButtons(selectedSkill, data(), allRaise1, allRaise10);
+            RefreshSkillRaiseButtons(selectedSkill, sheet, allRaise1, allRaise10);
+        }
+
+        void SoftRefreshSkillRows()
+        {
+            CharacterSheet sheet = data();
+            for (int i = 0; i < currentSkillRows.Count; i++)
+            {
+                SkillRowBinding row = currentSkillRows[i];
+                if (FindSkill(sheet, row.Skill.Id) is { } live)
+                    currentSkillRows[i] = row with { Skill = live };
+            }
         }
 
         void RefreshAfterRaise(uint? selectedSkillId)
@@ -439,23 +451,31 @@ public static class CharacterStatController
                     selectedSkillId = currentSkillRows[skillSel[0]].Skill.Id;
                 }
 
-                RebuildActiveList();
-
-                skillSel[0] = -1;
-                if (selectedSkillId is uint id)
+                // Row values already follow data(); only rebuild when bucket/order identity changes.
+                if (!SkillLayoutMatches(currentSkillRows, data()))
                 {
-                    for (int i = 0; i < currentSkillRows.Count; i++)
+                    RebuildActiveList();
+
+                    skillSel[0] = -1;
+                    if (selectedSkillId is uint id)
                     {
-                        if (currentSkillRows[i].Skill.Id == id)
+                        for (int i = 0; i < currentSkillRows.Count; i++)
                         {
-                            skillSel[0] = i;
-                            break;
+                            if (currentSkillRows[i].Skill.Id == id)
+                            {
+                                skillSel[0] = i;
+                                break;
+                            }
                         }
                     }
-                }
 
-                ApplySkillSelectionVisuals(skillSel[0], currentSkillRows, spriteResolve);
-                SetFooterSelected(skillSel[0] >= 0);
+                    ApplySkillSelectionVisuals(skillSel[0], currentSkillRows, spriteResolve);
+                    SetFooterSelected(skillSel[0] >= 0);
+                }
+                else
+                {
+                    SoftRefreshSkillRows();
+                }
             }
 
             RefreshActiveRaiseButtons();
@@ -465,6 +485,37 @@ public static class CharacterStatController
             () => RefreshAfterRaise(null),
             SwitchTab,
             () => activeTab[0]);
+    }
+
+    /// <summary>
+    /// True when the skills list still has the same ordered identity that
+    /// <see cref="BuildSkillRows"/> would produce (ids, advancement class, and
+    /// usable-untrained flag). Level/cost changes do not count as layout changes.
+    /// </summary>
+    private static bool SkillLayoutMatches(
+        IReadOnlyList<SkillRowBinding> rows,
+        CharacterSheet sheet)
+    {
+        int expectedCount = 0;
+        int rowIndex = 0;
+        foreach (CharacterSkill skill in EnumerateDisplaySkills(sheet))
+        {
+            expectedCount++;
+            if (rowIndex >= rows.Count)
+                return false;
+
+            CharacterSkill bound = rows[rowIndex].Skill;
+            if (bound.Id != skill.Id
+                || bound.AdvancementClass != skill.AdvancementClass
+                || bound.UsableUntrained != skill.UsableUntrained)
+            {
+                return false;
+            }
+
+            rowIndex++;
+        }
+
+        return expectedCount == rows.Count;
     }
 
     private static UiScrollbar? PrepareSkillScrollbar(
@@ -782,23 +833,26 @@ public static class CharacterStatController
         return null;
     }
 
+    private static IEnumerable<CharacterSkill> EnumerateDisplaySkills(CharacterSheet sheet)
+    {
+        foreach (var skill in OrderedSkills(sheet, CharacterSkillAdvancementClass.Specialized, usableUntrained: null))
+            yield return skill;
+        foreach (var skill in OrderedSkills(sheet, CharacterSkillAdvancementClass.Trained, usableUntrained: null))
+            yield return skill;
+        foreach (var skill in OrderedSkills(sheet, CharacterSkillAdvancementClass.Untrained, usableUntrained: true))
+            yield return skill;
+        foreach (var skill in OrderedSkills(sheet, CharacterSkillAdvancementClass.Untrained, usableUntrained: false))
+            yield return skill;
+    }
+
     private static CharacterSkill? SkillAtDisplayIndex(CharacterSheet sheet, int index)
     {
         if (index < 0) return null;
         int n = 0;
-        foreach (var bucket in new[]
+        foreach (var skill in EnumerateDisplaySkills(sheet))
         {
-            OrderedSkills(sheet, CharacterSkillAdvancementClass.Specialized, usableUntrained: null),
-            OrderedSkills(sheet, CharacterSkillAdvancementClass.Trained, usableUntrained: null),
-            OrderedSkills(sheet, CharacterSkillAdvancementClass.Untrained, usableUntrained: true),
-            OrderedSkills(sheet, CharacterSkillAdvancementClass.Untrained, usableUntrained: false),
-        })
-        {
-            foreach (var skill in bucket)
-            {
-                if (n == index) return skill;
-                n++;
-            }
+            if (n == index) return skill;
+            n++;
         }
         return null;
     }
@@ -908,8 +962,12 @@ public static class CharacterStatController
 
         ApplySkillSelectionVisuals(newSel, rows, spriteResolve);
 
-        CharacterSkill? selectedSkill = newSel >= 0 && newSel < rows.Count ? rows[newSel].Skill : null;
-        RefreshSkillRaiseButtons(selectedSkill, data(), allRaise1, allRaise10);
+        CharacterSheet sheet = data();
+        CharacterSkill? selectedSkill =
+            newSel >= 0 && newSel < rows.Count
+                ? FindSkill(sheet, rows[newSel].Skill.Id)
+                : null;
+        RefreshSkillRaiseButtons(selectedSkill, sheet, allRaise1, allRaise10);
     }
 
     private static void ApplySkillSelectionVisuals(
@@ -1071,10 +1129,12 @@ public static class CharacterStatController
         else
         {
             var rows = skillRows();
-            CharacterSkill? selectedSkill =
+            uint? selectedId =
                 skillSel[0] >= 0 && skillSel[0] < rows.Count
-                    ? rows[skillSel[0]].Skill
+                    ? rows[skillSel[0]].Skill.Id
                     : null;
+            CharacterSkill? selectedSkill =
+                selectedId is uint id ? FindSkill(sheet, id) : null;
             selectedSkillId = selectedSkill?.Id;
             request = TryBuildSkillRaiseRequest(sheet, selectedSkill, amount);
         }

--- a/tests/AcDream.App.Tests/UI/Layout/CharacterStatControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/CharacterStatControllerTests.cs
@@ -1181,11 +1181,37 @@ public class CharacterStatControllerTests
         Assert.Equal(trainedBefore + 1, RowsUnderHeader(list, "Trained Skills"));
     }
 
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void DataChangedRefresh_PreservesSkillsScrollWithinTheNewContentBounds(
-        bool shrinkSkills)
+    [Fact]
+    public void DataChangedRefresh_WhenSkillLayoutUnchanged_KeepsViewportAndScroll()
+    {
+        var list = new UiPanel { Width = 300, Height = 60 };
+        var layout = Fake((CharacterStatController.ListBoxId, list));
+        CharacterSheet sheet = SampleData.SampleCharacter();
+        Action refresh = CharacterStatController.Bind(layout, () => sheet,
+            spriteResolve: id => (id, 16, 16)).Refresh;
+
+        ClickTab(layout, left: 92f);
+        UiScrollablePanel viewport = list.Children.OfType<UiScrollablePanel>().Single();
+        viewport.LayoutScrollableChildren();
+        Assert.True(viewport.Scroll.MaxScroll > 10);
+        int offset = viewport.Scroll.MaxScroll - 10;
+        viewport.Scroll.SetScrollY(offset);
+
+        sheet = new CharacterSheet
+        {
+            Name = sheet.Name,
+            UnassignedXp = sheet.UnassignedXp + 1,
+            SkillCredits = sheet.SkillCredits,
+            Skills = sheet.Skills,
+        };
+        refresh();
+
+        Assert.Same(viewport, list.Children.OfType<UiScrollablePanel>().Single());
+        Assert.Equal(offset, viewport.Scroll.ScrollY);
+    }
+
+    [Fact]
+    public void DataChangedRefresh_WhenSkillLayoutShrinks_RebuildsAndClampsScroll()
     {
         var list = new UiPanel { Width = 300, Height = 60 };
         var layout = Fake((CharacterStatController.ListBoxId, list));
@@ -1205,20 +1231,15 @@ public class CharacterStatControllerTests
             Name = sheet.Name,
             UnassignedXp = sheet.UnassignedXp + 1,
             SkillCredits = sheet.SkillCredits,
-            Skills = shrinkSkills ? sheet.Skills.Take(6).ToList() : sheet.Skills,
+            Skills = sheet.Skills.Take(6).ToList(),
         };
         refresh();
 
         UiScrollablePanel replacement = list.Children.OfType<UiScrollablePanel>().Single();
         Assert.NotSame(previous, replacement);
-        if (shrinkSkills)
-        {
-            Assert.True(replacement.Scroll.MaxScroll > 0);
-            Assert.True(replacement.Scroll.MaxScroll < offset);
-        }
-        Assert.Equal(Math.Min(offset, replacement.Scroll.MaxScroll), replacement.Scroll.ScrollY);
-        if (!shrinkSkills)
-            Assert.Equal(offset, replacement.Scroll.ScrollY);
+        Assert.True(replacement.Scroll.MaxScroll > 0);
+        Assert.True(replacement.Scroll.MaxScroll < offset);
+        Assert.Equal(replacement.Scroll.MaxScroll, replacement.Scroll.ScrollY);
     }
 
     [Fact]
@@ -1870,6 +1891,73 @@ public class CharacterStatControllerTests
 
         Assert.Equal("350", value.LinesProvider()[0].Text);
         Assert.Equal(new Vector4(0f, 1f, 0f, 1f), value.LinesProvider()[0].Color);
+    }
+
+    [Fact]
+    public void SkillsRefresh_WhenLayoutUnchanged_KeepsSameRowPanels()
+    {
+        var list = new UiPanel { Width = 300 };
+        var layout = Fake((CharacterStatController.ListBoxId, list));
+        CharacterSheet sheet = VitaeSkillSheet(
+            currentLevel: 300,
+            baseLevel: 300,
+            vitaeModifier: 0);
+
+        var binding = CharacterStatController.Bind(
+            layout,
+            () => sheet,
+            spriteResolve: id => (id, 16, 16));
+        ClickTab(layout, left: 92f);
+
+        UiClickablePanel before = Assert.Single(SkillRows(list));
+        sheet = VitaeSkillSheet(
+            currentLevel: 301,
+            baseLevel: 300,
+            vitaeModifier: 0);
+        binding.Refresh();
+
+        Assert.Same(before, Assert.Single(SkillRows(list)));
+    }
+
+    [Fact]
+    public void SkillsRefresh_WhenUnassignedXpChanges_UpdatesRaiseAffordability()
+    {
+        var list = new UiPanel { Width = 300 };
+        var btn1 = MakeButton();
+        var btn10 = MakeButton();
+        CharacterSheet sheet = VitaeSkillSheet(
+            currentLevel: 300,
+            baseLevel: 300,
+            vitaeModifier: 0);
+        var layout = Fake(
+            (CharacterStatController.ListBoxId, list),
+            (CharacterStatController.RaiseOneId, btn1),
+            (CharacterStatController.RaiseTenId, btn10));
+
+        var binding = CharacterStatController.Bind(
+            layout,
+            () => sheet,
+            spriteResolve: id => (id, 16, 16));
+        ClickTab(layout, left: 92f);
+        UiClickablePanel row = SkillRows(list)[0];
+        row.OnClick!();
+
+        Assert.Equal("Normal", btn1.ActiveState);
+        Assert.Equal("Normal", btn10.ActiveState);
+
+        sheet = new CharacterSheet
+        {
+            SkillCredits = sheet.SkillCredits,
+            UnassignedXp = 50,
+            Skills = sheet.Skills,
+        };
+        binding.Refresh();
+
+        Assert.Same(row, Assert.Single(SkillRows(list)));
+        Assert.Equal("Ghosted", btn1.ActiveState);
+        Assert.Equal("Ghosted", btn10.ActiveState);
+        Assert.True(btn1.Visible);
+        Assert.True(btn10.Visible);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Skills `Refresh` now soft-updates when skill layout identity is unchanged (ids / advancement class / usable-untrained), instead of always calling `RebuildActiveList`.
- Raise clicks and affordability refresh resolve the selected skill from the live sheet, not a stale row snapshot.
- Keeps #23 scroll preserve for real hard rebuilds (train / list shrink); retargets the scroll tests accordingly.

This addresses the root cause behind #22: routine `SubscribeChanged` fires (Age / XP / burden, etc.) were destroying the skills viewport even though row values already use live `data()` providers.

## Test plan
- [x] `CharacterStatControllerTests` (132) pass locally
- [ ] Open character Skills tab, scroll down, wait for periodic sheet updates — list should stay scrolled without jumping
- [ ] Select a skill, spend Unassigned XP elsewhere / watch XP tick — raise buttons update without list rebuild
- [ ] Train an untrained skill — list rebuilds into Trained bucket, selection preserved, scroll still sane

Made with [Cursor](https://cursor.com)