### PR TITLE
Fix combat power bar release (#27)

### DIFF
--- a/src/AcDream.Runtime/Gameplay/RuntimeCombatAttackState.cs
+++ b/src/AcDream.Runtime/Gameplay/RuntimeCombatAttackState.cs
@@ -357,16 +357,27 @@ public sealed class RuntimeCombatAttackState : IDisposable
     {
         _fireWhenCharged = false;
         StopBuild();
-        if (!_operations.SendAttack(
-                height,
-                Math.Clamp(_requestedAttackPower, 0f, 1f)))
+        float power = Math.Clamp(_requestedAttackPower, 0f, 1f);
+        if (!_operations.SendAttack(height, power))
         {
             ResetPowerBar();
             return;
         }
 
         if (_operations.AutoRepeatAttack)
+        {
             _repeatAttacking = true;
+            // Pre-queue the marker immediately after an overcharged opener so the
+            // next swing does not reuse the initiating power while we wait for
+            // AttackDone (common when running into melee range).
+            if (Math.Abs(power - DesiredPower) >= 0.01f)
+            {
+                _requestedAttackPower = DesiredPower;
+                _operations.SendAttack(
+                    height,
+                    Math.Clamp(DesiredPower, 0f, 1f));
+            }
+        }
         _attackServerResponsePending = setServerPending;
     }
 

--- a/src/AcDream.Runtime/Gameplay/RuntimeCombatAttackState.cs
+++ b/src/AcDream.Runtime/Gameplay/RuntimeCombatAttackState.cs
@@ -93,6 +93,7 @@ public sealed class RuntimeCombatAttackState : IDisposable
     private float _attackWhenResponseReceivedPower;
     private bool _currentBuildIsAutomatic;
     private bool _repeatAttacking;
+    private bool _fireWhenCharged;
     private float _requestedAttackPower;
     private float _latestPowerBarLevel;
     private bool _disposed;
@@ -219,14 +220,29 @@ public sealed class RuntimeCombatAttackState : IDisposable
 
         _attackRequestInProgress = false;
         float currentPower = GetPowerBarLevel();
-        _requestedAttackPower = Math.Min(DesiredPower, currentPower);
+
+        // Marker is the floor / auto-repeat default, not a hold ceiling.
+        // - Release at/above the marker: fire at the charged power (may be full).
+        // - Release below the marker, or before charge starts (missile ready wait):
+        //   keep loading up to the marker, then fire.
+        if (!_buildInProgress || currentPower < DesiredPower)
+        {
+            _requestedAttackPower = DesiredPower;
+            _fireWhenCharged = true;
+        }
+        else
+        {
+            _requestedAttackPower = currentPower;
+            _fireWhenCharged = false;
+        }
 
         if (_attackServerResponsePending)
         {
             _attackWhenResponseReceived = true;
             _attackWhenResponseReceivedPower = _requestedAttackPower;
+            _fireWhenCharged = false;
         }
-        else if (DesiredPower <= currentPower || _repeatAttacking)
+        else if (!_fireWhenCharged || DesiredPower <= currentPower || _repeatAttacking)
         {
             ExecuteAttack(RequestedHeight, setServerPending: true);
         }
@@ -238,11 +254,13 @@ public sealed class RuntimeCombatAttackState : IDisposable
     {
         if (!_attackServerResponsePending
             && !_attackRequestInProgress
+            && !_fireWhenCharged
             && !_repeatAttacking)
             return;
 
         _operations.SendCancelAttack();
         _repeatAttacking = false;
+        _fireWhenCharged = false;
 
         if (_buildInProgress)
             ResetPowerBar();
@@ -252,9 +270,9 @@ public sealed class RuntimeCombatAttackState : IDisposable
 
     public void Tick()
     {
-        if (_attackRequestInProgress
-            && !_buildInProgress
-            && !_attackServerResponsePending)
+        if (!_buildInProgress
+            && !_attackServerResponsePending
+            && (_attackRequestInProgress || _fireWhenCharged))
             AttemptStartBuildingAttack();
 
         if (!_buildInProgress)
@@ -262,7 +280,7 @@ public sealed class RuntimeCombatAttackState : IDisposable
 
         if (!_operations.PlayerReadyForAttack)
         {
-            if (_attackRequestInProgress)
+            if (_attackRequestInProgress || _fireWhenCharged)
             {
                 StopBuild();
                 _latestPowerBarLevel = 0f;
@@ -337,6 +355,7 @@ public sealed class RuntimeCombatAttackState : IDisposable
 
     private void ExecuteAttack(AttackHeight height, bool setServerPending)
     {
+        _fireWhenCharged = false;
         StopBuild();
         if (!_operations.SendAttack(
                 height,
@@ -441,6 +460,7 @@ public sealed class RuntimeCombatAttackState : IDisposable
         _attackWhenResponseReceived = false;
         _attackWhenResponseReceivedPower = 0f;
         _repeatAttacking = false;
+        _fireWhenCharged = false;
         _requestedAttackPower = 0f;
         _completionRevision = 0;
         CompletionSequence = 0u;

--- a/tests/AcDream.Runtime.Tests/Gameplay/RuntimeCombatAttackStateTests.cs
+++ b/tests/AcDream.Runtime.Tests/Gameplay/RuntimeCombatAttackStateTests.cs
@@ -87,6 +87,39 @@ public sealed class RuntimeCombatAttackStateTests
     }
 
     [Fact]
+    public void OverchargedOpener_WithAutoRepeat_PrequeuesMarkerPower()
+    {
+        double now = 0d;
+        var sent = new List<(AttackHeight Height, float Power)>();
+        var combat = new CombatState();
+        using var controller = new RuntimeCombatAttackState(
+            combat,
+            canStartAttack: () => true,
+            sendAttack: (height, power) =>
+            {
+                sent.Add((height, power));
+                return true;
+            },
+            autoRepeatAttack: () => true,
+            now: () => now);
+        combat.SetCombatMode(CombatMode.Melee);
+        controller.SetDesiredPower(0f);
+
+        controller.PressAttack(AttackHeight.High);
+        now = 1d;
+        controller.ReleaseAttack();
+
+        Assert.Equal(2, sent.Count);
+        Assert.Equal(1f, sent[0].Power, 3);
+        Assert.Equal(0f, sent[1].Power, 3);
+        Assert.Equal(0f, controller.RequestedAttackPower, 3);
+
+        combat.OnAttackDone(1u, 0u);
+        Assert.Equal(3, sent.Count);
+        Assert.Equal(0f, sent[2].Power, 3);
+    }
+
+    [Fact]
     public void HoldBinding_UsesPressAndReleaseTransitions()
     {
         double now = 1d;

--- a/tests/AcDream.Runtime.Tests/Gameplay/RuntimeCombatAttackStateTests.cs
+++ b/tests/AcDream.Runtime.Tests/Gameplay/RuntimeCombatAttackStateTests.cs
@@ -44,7 +44,7 @@ public sealed class RuntimeCombatAttackStateTests
     }
 
     [Fact]
-    public void EarlyRelease_CommitsOnUseTimeTickAtReleasedPower()
+    public void EarlyReleaseBelowMarker_KeepsChargingToDesiredPower()
     {
         double now = 0d;
         var sent = new List<(AttackHeight Height, float Power)>();
@@ -57,13 +57,33 @@ public sealed class RuntimeCombatAttackStateTests
         now = 0.25d;
         controller.ReleaseAttack();
         Assert.Empty(sent);
+        Assert.Equal(1f, controller.RequestedAttackPower, 3);
 
-        now = 0.26d;
+        now = 1d;
         controller.Tick();
 
         var attack = Assert.Single(sent);
         Assert.Equal(AttackHeight.Low, attack.Height);
-        Assert.Equal(0.25f, attack.Power, 3);
+        Assert.Equal(1f, attack.Power, 3);
+    }
+
+    [Fact]
+    public void HoldPastLowMarker_ReleasesAtChargedPower()
+    {
+        double now = 0d;
+        var sent = new List<(AttackHeight Height, float Power)>();
+        var combat = new CombatState();
+        using var controller = Create(combat, () => now, sent);
+        combat.SetCombatMode(CombatMode.Melee);
+        controller.SetDesiredPower(0f);
+
+        controller.PressAttack(AttackHeight.Medium);
+        now = 1d;
+        controller.ReleaseAttack();
+
+        var attack = Assert.Single(sent);
+        Assert.Equal(AttackHeight.Medium, attack.Height);
+        Assert.Equal(1f, attack.Power, 3);
     }
 
     [Fact]
@@ -127,6 +147,70 @@ public sealed class RuntimeCombatAttackStateTests
 
         Assert.True(controller.BuildInProgress);
         Assert.Equal(0f, controller.PowerBarLevel);
+    }
+
+    [Fact]
+    public void HoldPastMarker_DoesNotAutoReleaseAtSetpoint()
+    {
+        double now = 0d;
+        var sent = new List<(AttackHeight Height, float Power)>();
+        var combat = new CombatState();
+        using var controller = Create(combat, () => now, sent);
+        combat.SetCombatMode(CombatMode.Melee);
+        controller.SetDesiredPower(0.5f);
+
+        controller.PressAttack(AttackHeight.Medium);
+        now = 0.5d;
+        controller.Tick();
+        Assert.Empty(sent);
+        Assert.True(controller.AttackRequestInProgress);
+        Assert.Equal(0.5f, controller.PowerBarLevel, 3);
+
+        now = 1d;
+        controller.Tick();
+        Assert.Empty(sent);
+        Assert.True(controller.AttackRequestInProgress);
+        Assert.Equal(1f, controller.PowerBarLevel, 3);
+    }
+
+    [Fact]
+    public void ReleaseBeforeReadyStance_ChargesToDesiredPowerOnceReady()
+    {
+        double now = 0d;
+        bool ready = false;
+        var sent = new List<(AttackHeight Height, float Power)>();
+        var combat = new CombatState();
+        using var controller = new RuntimeCombatAttackState(
+            combat,
+            canStartAttack: () => true,
+            sendAttack: (height, power) =>
+            {
+                sent.Add((height, power));
+                return true;
+            },
+            playerReadyForAttack: () => ready,
+            now: () => now);
+        combat.SetCombatMode(CombatMode.Missile);
+        controller.SetDesiredPower(0.75f);
+
+        controller.PressAttack(AttackHeight.High);
+        controller.ReleaseAttack();
+        Assert.Empty(sent);
+        Assert.False(controller.AttackRequestInProgress);
+        Assert.False(controller.BuildInProgress);
+        Assert.Equal(0.75f, controller.RequestedAttackPower, 3);
+
+        ready = true;
+        controller.Tick();
+        Assert.True(controller.BuildInProgress);
+        Assert.Empty(sent);
+
+        now = 0.75d;
+        controller.Tick();
+
+        var attack = Assert.Single(sent);
+        Assert.Equal(AttackHeight.High, attack.Height);
+        Assert.Equal(0.75f, attack.Power, 3);
     }
 
     [Fact]


### PR DESCRIPTION
## What this changes
Fixes [#27](https://github.com/eriknihlen/OpenAC/issues/27): attacks were often sent at minimum power/accuracy because release capped charged power at the marker (`Math.Min(DesiredPower, currentPower)`), and releasing before the bar started (common for missile ready wait) locked in ~0.

- Treat the power/accuracy marker as a **floor / auto-repeat default**, not a hold ceiling
- Release at/above the marker → fire at the **charged** power (hold-past-low for a full first swing works)
- Release below the marker, or before charge starts → keep loading to the marker, then fire
- Auto-repeat still uses the marker for follow-ups

## Original behavior
In the original client, the combat panel marker sets preferred/repeat attack power. You can hold past that marker and release for a stronger initiating swing, then flow into marker-power attacks with Repeat Attacks. A quick release below the marker (or before missile ready stance lets the bar start) should still reach the marker rather than firing at zero. Verified against reporter repro on #27 and in-client hold-past / tap-at-full checks during this fix.

## Checklist
- [x] `dotnet build AcDream.slnx -c Release` is green
- [x] The portable test filter passes locally (see CONTRIBUTING.md)
- [x] One topic per PR
- [x] No code copied from ACEmulator, ACViewer, or holtburger
- [x] No comments describing the original client's internals

## Test plan
- [ ] Melee: set marker low, hold attack through full bar, release → first swing at full power; with Repeat Attacks, follow-ups at marker
- [ ] Melee/missile: set marker full, tap attack → charges to marker (not min power)
- [ ] Archery: enter missile mode and attack; accuracy follows the marker instead of staying at min
- [ ] Confirm you can hold past the marker without auto-firing at the setpoint
- [ ] `dotnet test tests/AcDream.Runtime.Tests --filter FullyQualifiedName~RuntimeCombatAttackStateTests`


Made with [Cursor](https://cursor.com)