### PR TITLE
Keep item cells alive when only their properties change

### DIFF
--- a/src/AcDream.App/UI/Layout/ExternalContainerController.cs
+++ b/src/AcDream.App/UI/Layout/ExternalContainerController.cs
@@ -306,15 +306,12 @@ public sealed class ExternalContainerController : IItemListDragHandler, IRetaine
         using IDisposable topLayout = _topContainer.DeferLayout();
         using IDisposable containerLayout = _containerList.DeferLayout();
         using IDisposable contentsLayout = _contentsList.DeferLayout();
-        _topContainer.Flush();
-        _containerList.Flush();
-        _contentsList.Flush();
 
-        AddRootCell(root);
+        var visibleContainers = new List<uint>();
         foreach (uint guid in _objects.GetContents(root))
         {
             if (IsContainer(_objects.Get(guid)))
-                AddContainerCell(guid);
+                visibleContainers.Add(guid);
         }
 
         var visibleContents = new List<uint>();
@@ -333,15 +330,83 @@ public sealed class ExternalContainerController : IItemListDragHandler, IRetaine
                 Math.Clamp(pending.Placement, 0, visibleContents.Count),
                 pending.ItemId);
         }
-        foreach (uint guid in visibleContents)
+        // Flushing cells cancels a press in progress: UiRoot releases capture when the
+        // captured element leaves the tree.
+        if (TryRefreshCellsInPlace(root, visibleContainers, visibleContents))
         {
-            bool waiting = _itemInteraction.IsPendingInventorySource(guid)
-                || _pendingPlacement is { } projection
-                    && projection.ContainerId == _openContainer
-                    && projection.ItemId == guid;
-            AddContentsCell(guid, waiting);
+            ApplyIndicators();
+            return;
         }
+
+        _topContainer.Flush();
+        _containerList.Flush();
+        _contentsList.Flush();
+
+        AddRootCell(root);
+        foreach (uint guid in visibleContainers)
+            AddContainerCell(guid);
+
+        foreach (uint guid in visibleContents)
+            AddContentsCell(guid, IsWaiting(guid));
         ApplyIndicators();
+    }
+
+    private bool IsWaiting(uint guid)
+        => _itemInteraction.IsPendingInventorySource(guid)
+            || (_pendingPlacement is { } projection
+                && projection.ContainerId == _openContainer
+                && projection.ItemId == guid);
+
+    /// <summary>False when anything structural moved, which needs the rebuild.</summary>
+    private bool TryRefreshCellsInPlace(
+        uint root,
+        IReadOnlyList<uint> visibleContainers,
+        IReadOnlyList<uint> visibleContents)
+    {
+        if (_topContainer.GetNumUIItems() != 1
+            || _topContainer.GetItem(0)?.ItemId != root
+            || !Matches(_containerList, visibleContainers)
+            || !Matches(_contentsList, visibleContents))
+        {
+            return false;
+        }
+
+        RefreshIcons(_topContainer, [root]);
+        SetCapacity(_topContainer.GetItem(0)!, root);
+        RefreshIcons(_containerList, visibleContainers);
+        for (int i = 0; i < visibleContainers.Count; i++)
+            SetCapacity(_containerList.GetItem(i)!, visibleContainers[i]);
+        RefreshIcons(_contentsList, visibleContents);
+        for (int i = 0; i < visibleContents.Count; i++)
+            _contentsList.GetItem(i)!.SetWaitingState(IsWaiting(visibleContents[i]));
+        return true;
+    }
+
+    // The lists pad themselves with empty cells (FillVisibleEmptySlots).
+    private static bool Matches(UiItemList list, IReadOnlyList<uint> guids)
+    {
+        if (list.GetNumUIItems() < guids.Count) return false;
+        for (int i = 0; i < list.GetNumUIItems(); i++)
+        {
+            uint expected = i < guids.Count ? guids[i] : 0u;
+            if (list.GetItem(i) is not { } cell || cell.ItemId != expected) return false;
+        }
+        return true;
+    }
+
+    private void RefreshIcons(UiItemList list, IReadOnlyList<uint> guids)
+    {
+        for (int i = 0; i < guids.Count; i++)
+        {
+            if (list.GetItem(i) is not { } cell) continue;
+            uint guid = guids[i];
+            ClientObject? item = _objects.Get(guid);
+            uint icon = item is null ? 0u : _resolveIcon(
+                item.Type, item.IconId, item.IconUnderlayId, item.IconOverlayId, item.Effects);
+            uint dragIcon = item is null ? 0u : _resolveDragIcon(
+                item.Type, item.IconId, item.IconUnderlayId, item.IconOverlayId, item.Effects);
+            cell.SetItem(guid, icon, dragIconTexture: dragIcon);
+        }
     }
 
     private void AddRootCell(uint guid)
@@ -512,12 +577,22 @@ public sealed class ExternalContainerController : IItemListDragHandler, IRetaine
     }
 
     private void OnSelectionChanged(SelectionTransition _) => ApplyIndicators();
-    private void OnInteractionStateChanged()
+    // A transaction only changes which cells are waiting on it.
+    private void OnInteractionStateChanged() => ApplyTransactionStates();
+
+    private void ApplyTransactionStates()
     {
-        if (_window.IsVisible)
-            Populate();
-        else
-            ApplyIndicators();
+        for (int i = 0; i < _contentsList.GetNumUIItems(); i++)
+        {
+            if (_contentsList.GetItem(i) is not { ItemId: not 0u } cell) continue;
+            cell.SetWaitingState(
+                _itemInteraction.IsPendingInventorySource(cell.ItemId)
+                || (_pendingPlacement is { } projection
+                    && projection.ContainerId == _openContainer
+                    && projection.ItemId == cell.ItemId));
+        }
+
+        ApplyIndicators();
     }
 
     private void OnPendingPlacementRequested(PendingBackpackPlacement pending)

--- a/src/AcDream.App/UI/Layout/InventoryController.cs
+++ b/src/AcDream.App/UI/Layout/InventoryController.cs
@@ -281,7 +281,35 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
         if (containerId == EffectiveOpen() || containerId == _playerGuid())
             Populate();
     }
-    private void OnInteractionStateChanged() => Populate();
+    // A transaction only changes which cells are waiting on it.
+    private void OnInteractionStateChanged() => ApplyTransactionStates();
+
+    private void ApplyTransactionStates()
+    {
+        PendingListPlacement? pending = _pendingListPlacement;
+        ApplyWaitingStates(_containerList, _playerGuid(), pending);
+        ApplyWaitingStates(_contentsGrid, EffectiveOpen(), pending);
+        if (_topContainer?.GetItem(0) is { ItemId: not 0u } main)
+            main.SetWaitingState(IsWaitingSource(main.ItemId));
+        ApplyIndicators();
+    }
+
+    private void ApplyWaitingStates(
+        UiItemList? list,
+        uint containerId,
+        PendingListPlacement? pending)
+    {
+        if (list is null) return;
+        for (int i = 0; i < list.GetNumUIItems(); i++)
+        {
+            if (list.GetItem(i) is not { ItemId: not 0u } cell) continue;
+            cell.SetWaitingState(
+                IsWaitingSource(cell.ItemId)
+                || (pending is { } projection
+                    && projection.ContainerId == containerId
+                    && projection.ItemId == cell.ItemId));
+        }
+    }
     private void OnPendingBackpackPlacementRequested(PendingBackpackPlacement pending)
     {
         if (_pendingListPlacement is not null
@@ -348,9 +376,6 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
         uint p = _playerGuid();
         uint open = EffectiveOpen();
 
-        _contentsGrid?.Flush();
-        _containerList?.Flush();
-
         var visibleBags = new List<uint>();
         foreach (var guid in _objects.GetContents(p))
         {
@@ -369,15 +394,6 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
             visibleBags.Remove(bagProjection.ItemId);
             int index = Math.Clamp(bagProjection.Placement, 0, visibleBags.Count);
             visibleBags.Insert(index, bagProjection.ItemId);
-        }
-
-        foreach (uint guid in visibleBags)
-        {
-            bool waiting = IsWaitingSource(guid)
-                || pending is { } waitingBagProjection
-                    && waitingBagProjection.ContainerId == p
-                    && waitingBagProjection.ItemId == guid;
-            AddCell(_containerList, guid, isContainer: true, waiting);
         }
 
         var visibleContents = new List<uint>();
@@ -399,13 +415,34 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
             visibleContents.Insert(index, projection.ItemId);
         }
 
+        // Flushing cells cancels a press in progress: UiRoot releases capture when the
+        // captured element leaves the tree.
+        if (TryRefreshCellsInPlace(visibleBags, visibleContents, pending, p, open))
+        {
+            ApplyIndicators();
+            RefreshBurden();
+            return;
+        }
+
+        _containerList?.Flush();
+        _contentsGrid?.Flush();
+
+        foreach (uint guid in visibleBags)
+        {
+            AddCell(
+                _containerList,
+                guid,
+                isContainer: true,
+                IsWaiting(guid, p, pending));
+        }
+
         foreach (uint guid in visibleContents)
         {
-            bool waiting = IsWaitingSource(guid)
-                || pending is { } waitingProjection
-                && waitingProjection.ContainerId == open
-                && waitingProjection.ItemId == guid;
-            AddCell(_contentsGrid, guid, isContainer: false, waiting);
+            AddCell(
+                _contentsGrid,
+                guid,
+                isContainer: false,
+                IsWaiting(guid, open, pending));
         }
 
         if (_contentsGrid is not null)
@@ -473,6 +510,96 @@ public sealed class InventoryController : IItemListDragHandler, IRetainedPanelCo
     private uint EffectiveOpen() => _openContainer != 0 ? _openContainer : _playerGuid();
 
     public uint CurrentOpenContainerId => EffectiveOpen();
+
+    private bool IsWaiting(uint guid, uint containerId, PendingListPlacement? pending)
+        => IsWaitingSource(guid)
+            || (pending is { } projection
+                && projection.ContainerId == containerId
+                && projection.ItemId == guid);
+
+    /// <summary>False when anything structural moved, which needs the rebuild.</summary>
+    private bool TryRefreshCellsInPlace(
+        IReadOnlyList<uint> visibleBags,
+        IReadOnlyList<uint> visibleContents,
+        PendingListPlacement? pending,
+        uint player,
+        uint open)
+    {
+        if (!MatchesCells(_containerList, visibleBags, ContainerSlotTarget(player, visibleBags.Count))
+            || !MatchesCells(_contentsGrid, visibleContents, ContentsSlotTarget(open, player)))
+        {
+            return false;
+        }
+
+        RefreshCells(_containerList, visibleBags, isContainer: true, player, pending);
+        RefreshCells(_contentsGrid, visibleContents, isContainer: false, open, pending);
+        RefreshTopContainer(player);
+        return true;
+    }
+
+    private static bool MatchesCells(UiItemList? list, IReadOnlyList<uint> guids, int slotTarget)
+    {
+        if (list is null) return guids.Count == 0;
+        if (list.GetNumUIItems() != slotTarget) return false;
+        for (int i = 0; i < slotTarget; i++)
+        {
+            uint expected = i < guids.Count ? guids[i] : 0u;
+            if (list.GetItem(i) is not { } cell || cell.ItemId != expected) return false;
+        }
+        return true;
+    }
+
+    private void RefreshCells(
+        UiItemList? list,
+        IReadOnlyList<uint> guids,
+        bool isContainer,
+        uint containerId,
+        PendingListPlacement? pending)
+    {
+        if (list is null) return;
+        for (int i = 0; i < guids.Count; i++)
+        {
+            if (list.GetItem(i) is not { } cell) continue;
+            uint guid = guids[i];
+            ClientObject? item = _objects.Get(guid);
+            uint tex = item is null
+                ? 0u
+                : _iconIds(item.Type, item.IconId, item.IconUnderlayId, item.IconOverlayId, item.Effects);
+            uint dragTex = item is null
+                ? 0u
+                : _dragIconIds?.Invoke(
+                    item.Type, item.IconId, item.IconUnderlayId, item.IconOverlayId, item.Effects) ?? 0u;
+            cell.SetItem(guid, tex, dragIconTexture: dragTex);
+            SetStructureBar(cell, item);
+            cell.SetWaitingState(IsWaiting(guid, containerId, pending));
+            if (isContainer)
+                SetCapacityBar(cell, guid);
+        }
+    }
+
+    private void RefreshTopContainer(uint player)
+    {
+        if (_topContainer?.GetItem(0) is not { } main) return;
+        main.SetWaitingState(IsWaitingSource(player));
+        SetCapacityBar(main, player);
+    }
+
+    // Never from the cells on screen: a capacity change has to reach the rebuild.
+    private int ContainerSlotTarget(uint player, int bagCount)
+    {
+        if (_containerList is null) return 0;
+        int capacity = _objects.Get(player)?.ContainersCapacity ?? 0;
+        int slots = capacity > 0 ? capacity : SideBagSlots;
+        slots = Math.Max(slots, bagCount);
+        return Math.Min(slots, SideBagSlots);
+    }
+
+    private int ContentsSlotTarget(uint open, uint player)
+    {
+        if (_contentsGrid is null) return 0;
+        int cap = _objects.Get(open)?.ItemsCapacity ?? 0;
+        return cap > 0 ? cap : (open == player ? MainPackSlots : SidePackSlots);
+    }
 
     private void AddCell(UiItemList? list, uint guid, bool isContainer, bool waiting = false)
     {

--- a/tests/AcDream.App.Tests/UI/Layout/ExternalContainerControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/ExternalContainerControllerTests.cs
@@ -163,6 +163,38 @@ public sealed class ExternalContainerControllerTests
     }
 
     [Fact]
+    public void InteractionStateChange_refreshesCellsInPlace_withoutRebuilding()
+    {
+        using var h = new Harness();
+        h.Open(Chest, new ContainerContentEntry(Item, 0u));
+
+        UiItemSlot cell = h.Contents.GetItem(0)!;
+        UiItemSlot chest = h.Top.GetItem(0)!;
+
+        h.Interaction.IncrementBusyCount();
+
+        Assert.Same(cell, h.Contents.GetItem(0));
+        Assert.Same(chest, h.Top.GetItem(0));
+    }
+
+    [Fact]
+    public void AppraisalResponse_keepsContentsCellsAlive()
+    {
+        using var h = new Harness();
+        h.Open(Chest, new ContainerContentEntry(Item, 0u));
+
+        UiItemSlot cell = h.Contents.GetItem(0)!;
+        UiItemSlot chest = h.Top.GetItem(0)!;
+
+        var properties = new PropertyBundle();
+        properties.Ints[1u] = 42;
+        Assert.True(h.Objects.UpdateAppraisal(Item, properties, Array.Empty<uint>()));
+
+        Assert.Same(cell, h.Contents.GetItem(0));
+        Assert.Same(chest, h.Top.GetItem(0));
+    }
+
+    [Fact]
     public void AuthoritativeView_ShowsAuthoredStripAndPopulatesLists()
     {
         using var h = new Harness();

--- a/tests/AcDream.App.Tests/UI/Layout/InventoryControllerTests.cs
+++ b/tests/AcDream.App.Tests/UI/Layout/InventoryControllerTests.cs
@@ -568,6 +568,135 @@ public class InventoryControllerTests
     }
 
     [Fact]
+    public void InteractionStateChange_refreshesCellsInPlace_withoutRebuilding()
+    {
+        var (layout, grid, containers, top, _, _, _, _) = BuildLayout();
+        var objects = new ClientObjectTable();
+        SeedContained(objects, 0xAu, Player, slot: 0);
+        using var interaction = new ItemInteractionController(
+            objects,
+            new AcDream.Runtime.Gameplay.RuntimeInteractionTransactionState(
+                new InventoryTransactionState(objects)),
+            new InteractionState(),
+            playerGuid: () => Player,
+            sendUse: null,
+            sendUseWithTarget: null,
+            sendWield: null,
+            sendDrop: null);
+        Bind(layout, objects, itemInteraction: interaction);
+
+        UiItemSlot cell = grid.GetItem(0)!;
+        UiItemSlot bagCell = containers.GetItem(0)!;
+        UiItemSlot mainPack = top.GetItem(0)!;
+
+        interaction.IncrementBusyCount();
+
+        Assert.Same(cell, grid.GetItem(0));
+        Assert.Same(bagCell, containers.GetItem(0));
+        Assert.Same(mainPack, top.GetItem(0));
+    }
+
+    [Fact]
+    public void PressedCellSurvivesAppraisalOnSelection_soTheFirstClickCanDrag()
+    {
+        var (layout, grid, _, _, _, _, _, _) = BuildLayout();
+        var objects = new ClientObjectTable();
+        SeedContained(objects, 0xAu, Player, slot: 0);
+        var selection = new SelectionState();
+        var appraisals = new List<uint>();
+        using var interaction = new ItemInteractionController(
+            objects,
+            new AcDream.Runtime.Gameplay.RuntimeInteractionTransactionState(
+                new InventoryTransactionState(objects)),
+            new InteractionState(),
+            playerGuid: () => Player,
+            sendUse: null,
+            sendUseWithTarget: null,
+            sendWield: null,
+            sendDrop: null,
+            sendExamine: appraisals.Add);
+        Bind(layout, objects, selection: selection, itemInteraction: interaction);
+
+        // What AppraisalUiController does while its window is open.
+        selection.Changed += transition =>
+        {
+            if (transition.SelectedObjectId is uint id && id != 0u)
+                interaction.ExamineSelectedOrEnterMode(id);
+        };
+
+        // BuildLayout leaves every list at the origin.
+        grid.Left = 0;
+        grid.Top = 260;
+        var root = new UiRoot { Width = 800, Height = 600 };
+        root.AddChild(layout.Root);
+
+        UiItemSlot cell = grid.GetItem(0)!;
+        var (cellX, cellY) = AbsoluteCentre(cell);
+
+        root.OnMouseMove(cellX, cellY);
+        root.OnMouseDown(UiMouseButton.Left, cellX, cellY);
+
+        Assert.Equal(0xAu, selection.SelectedObjectId);
+        Assert.Equal(new uint[] { 0xAu }, appraisals);
+        Assert.Equal(1, interaction.BusyCount);
+
+        Assert.Same(cell, grid.GetItem(0));
+        Assert.Same(cell, root.Captured);
+
+        root.OnMouseMove(cellX + 12, cellY);
+
+        Assert.Same(cell, root.DragSource);
+        var payload = Assert.IsType<ItemDragPayload>(root.DragPayload);
+        Assert.Equal(0xAu, payload.ObjId);
+    }
+
+    [Fact]
+    public void PressedCellSurvivesAppraisalResponse_soTheFirstClickCanDrag()
+    {
+        var (layout, grid, _, _, _, _, _, _) = BuildLayout();
+        var objects = new ClientObjectTable();
+        SeedContained(objects, 0xAu, Player, slot: 0);
+        Bind(layout, objects);
+
+        grid.Left = 0;
+        grid.Top = 260;
+        var root = new UiRoot { Width = 800, Height = 600 };
+        root.AddChild(layout.Root);
+
+        UiItemSlot cell = grid.GetItem(0)!;
+        var (cellX, cellY) = AbsoluteCentre(cell);
+
+        root.OnMouseMove(cellX, cellY);
+        root.OnMouseDown(UiMouseButton.Left, cellX, cellY);
+        Assert.Same(cell, root.Captured);
+
+        // What GameEventWiring does with an appraisal reply.
+        var properties = new PropertyBundle();
+        properties.Ints[1u] = 42;
+        Assert.True(objects.UpdateAppraisal(0xAu, properties, Array.Empty<uint>()));
+
+        Assert.Same(cell, grid.GetItem(0));
+        Assert.Same(cell, root.Captured);
+
+        root.OnMouseMove(cellX + 12, cellY);
+
+        Assert.Same(cell, root.DragSource);
+        var payload = Assert.IsType<ItemDragPayload>(root.DragPayload);
+        Assert.Equal(0xAu, payload.ObjId);
+    }
+
+    private static (int x, int y) AbsoluteCentre(UiElement element)
+    {
+        float x = 0f, y = 0f;
+        for (UiElement? e = element; e is not null; e = e.Parent)
+        {
+            x += e.Left;
+            y += e.Top;
+        }
+        return ((int)(x + element.Width / 2f), (int)(y + element.Height / 2f));
+    }
+
+    [Fact]
     public void TargetMode_suppressesSelectedSquare_onPendingSource()
     {
         var (layout, grid, _, _, _, _, _, _) = BuildLayout();

--- a/tests/AcDream.Headless.Tests/LauncherHeadlessCommandLineContractTests.cs
+++ b/tests/AcDream.Headless.Tests/LauncherHeadlessCommandLineContractTests.cs
@@ -2,6 +2,7 @@ using AcDream.Headless.Configuration;
 using AcDream.Launcher.Core.Launching;
 using AcDream.Launcher.Core.Orchestration;
 using AcDream.Launcher.Core.Profiles;
+using AcDream.Launcher.Core.Updates;
 
 namespace AcDream.Headless.Tests;
 
@@ -15,9 +16,14 @@ public sealed class LauncherHeadlessCommandLineContractTests : IDisposable
     public LauncherHeadlessCommandLineContractTests()
     {
         Directory.CreateDirectory(AppDirectory);
-        string suffix = OperatingSystem.IsWindows() ? ".exe" : string.Empty;
-        CreateStubExecutable(Path.Combine(AppDirectory, "AcDream.App" + suffix));
-        CreateStubExecutable(Path.Combine(AppDirectory, "acdream-headless" + suffix));
+        // The resolver picks the graphical host per OS; the stub has to match.
+        string suffix = PayloadExecutableNames.SuffixForCurrentOs();
+        CreateStubExecutable(
+            Path.Combine(
+                AppDirectory,
+                PayloadExecutableNames.GraphicalHostForCurrentOs() + suffix));
+        CreateStubExecutable(
+            Path.Combine(AppDirectory, PayloadExecutableNames.HeadlessHost + suffix));
     }
 
     private static void CreateStubExecutable(string path)


### PR DESCRIPTION
Fixes #5.

The first click on an inventory item was swallowed whenever the appraisal panel was open.
@ddweller narrowed it to that on the issue, which is what made it findable.

Pressing an item selects it. With the panel open it re-examines the new selection, the reply
merges properties into the object, and `ObjectUpdated` fires while the button is still down.
`Populate()` flushes every cell, and `UiRoot` releases capture and clears the drag candidate when
the captured cell leaves the tree, so the press dies before it can become a drag or a double click.
The second click works because the item is already selected, so nothing rebuilds.

Both inventory controllers now reuse their cells when the visible set is unchanged, and rebuild
only when an item is added, moved or removed, or capacity changes. The same teardown fires on a
stack merge or a burden tick, so this was never limited to appraisals.

Five tests, each checked failing against `c9959ca`. Portable gate on an Apple silicon Mac:
18342 passed, 0 failed. Confirmed in the client, first click drags again, from the backpack and
from an open container.

The second commit is unrelated and one line. The headless contract test stubs `AcDream.App`, but
the resolver asks for `acdream-client` on macOS, so two cases fail there. Windows and Linux pass
legitimately, and `macos-portable` never runs that project. Happy to split it out.

Not verified on Windows.