### PR TITLE
A GUID-less pickup refusal wedges looting for the rest of the session

### DIFF
--- a/src/AcDream.Core/Items/InventoryTransactionState.cs
+++ b/src/AcDream.Core/Items/InventoryTransactionState.cs
@@ -299,11 +299,12 @@ public sealed class InventoryTransactionState : IDisposable
 
     private void OnMoveFailed(MoveRequestFailure failure)
     {
-        if (CompleteInventoryResponse(failure.ItemId, _objects.Get(failure.ItemId))
-            is { } failed)
-        {
+        uint itemId = failure.ItemId;
+        // A guid-less refusal can only be about the sole pending request.
+        if (itemId == 0u && _pendingRequest is { } current)
+            itemId = current.ItemId;
+        if (CompleteInventoryResponse(itemId, _objects.Get(itemId)) is { } failed)
             Dispatch(RequestFailed, failed, failure.WeenieError);
-        }
     }
 
     private void OnObjectRemoved(ClientObject item) =>

--- a/tests/AcDream.Core.Tests/Items/InventoryTransactionStateTests.cs
+++ b/tests/AcDream.Core.Tests/Items/InventoryTransactionStateTests.cs
@@ -281,6 +281,28 @@ public sealed class InventoryTransactionStateTests
         Assert.Equal(1, failures);
     }
 
+    [Fact]
+    public void RejectMoveWithNoGuidResolvesTheSoleOutstandingPendingRequest()
+    {
+        var objects = CreateTable();
+        using var state = new InventoryTransactionState(objects);
+        var failures = new List<(PendingInventoryRequest Request, uint Error)>();
+        state.RequestFailed += (request, error) => failures.Add((request, error));
+
+        Assert.True(state.TryDispatch(InventoryRequestKind.Pickup, First, static () => true));
+
+        // Observed: InventoryServerSaveFailed guid=0x00000000 on a quest-cooldown pickup refusal.
+        objects.RejectMove(0u, 0x43Eu);
+
+        (PendingInventoryRequest failed, uint error) = Assert.Single(failures);
+        Assert.Equal(First, failed.ItemId);
+        Assert.Equal(0x43Eu, error);
+        Assert.False(state.HasPendingRequest);
+
+        // The gate must reopen: the next request (standing in for the next corpse's "use") must dispatch.
+        Assert.True(state.TryDispatch(InventoryRequestKind.Pickup, Second, static () => true));
+    }
+
     private static ClientObjectTable CreateTable()
     {
         var objects = new ClientObjectTable();


### PR DESCRIPTION
Picking up a quest item whose solve-again timer has not expired gets refused by the server, and
after that refusal I could not open any corpse or loot anything for the rest of the session.
Reproduced on macOS against a local ACEmulator; I have not tested Windows or Linux.

The client logs the refusal as `InventoryServerSaveFailed guid=0x00000000 err=0x43E`
(`YouHaveSolvedThisQuestTooRecently`). `InventoryTransactionState.OnMoveFailed` matched a failure
only against the wire item guid, and this refusal class carries no guid at all. With the real
pending item's guid never matching zero, the pending request never resolved: it latched
permanently, and `CanMakeInventoryRequest` blocked every later inventory request, including the
`use` on a corpse double-click. `pick` still fired, `use` never followed.

The fix: when a move failure carries no item guid and exactly one request is pending, resolve
that pending request instead of requiring an exact guid match. One method,
`InventoryTransactionState.OnMoveFailed`. It does not touch the existing guarantee that a wrong,
nonzero guid still leaves the pending request untouched; that test still passes unmodified.

A new test, `RejectMoveWithNoGuidResolvesTheSoleOutstandingPendingRequest`, fails on `main`
(`Assert.Single()` on an empty collection) and passes on the branch. The targeted test class runs
14 of 14 green. Live: I reproduced the exact refusal on the branch and confirmed a corpse opened
normally afterward, where before the fix nothing opened for the rest of the session.

Upstream's full portable test filter passes on this branch: 14 assemblies, 0 failures. Not
verified: Windows or Linux.

Fixes #45.