### PR TITLE
Point the Vulkan loader at the packaged MoltenVK driver on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           dotnet test tests/AcDream.Platform.Tests/AcDream.Platform.Tests.csproj -c Release --no-build --nologo --filter $filter
           dotnet test tests/AcDream.App.Tests/AcDream.App.Tests.csproj -c Release --no-build --nologo --filter 'FullyQualifiedName~MacMonotonicFramePacingWaiterTests'
           dotnet test tests/AcDream.App.Tests/AcDream.App.Tests.csproj -c Release --no-build --nologo --filter 'FullyQualifiedName~AppCredentialResolverTests&Lane=MacOS'
+          dotnet test tests/AcDream.App.Tests/AcDream.App.Tests.csproj -c Release --no-build --nologo --filter 'FullyQualifiedName~GraphicalVulkanLoaderTests'
 
       - name: Build and verify the Apple-silicon release payloads
         shell: pwsh

--- a/src/AcDream.App/Platform/GraphicalVulkanLoader.cs
+++ b/src/AcDream.App/Platform/GraphicalVulkanLoader.cs
@@ -9,9 +9,10 @@ internal sealed record PackagedVulkanLayout(
     string DriverLibraryPath,
     string DriverManifestPath);
 
-internal static unsafe class GraphicalVulkanLoader
+internal static unsafe partial class GraphicalVulkanLoader
 {
     internal const string DriverFilesEnvironmentVariable = "VK_DRIVER_FILES";
+    private const int NativeEnvironmentCallSuccess = 0;
 
     private static readonly object Gate = new();
     private static string? _packagedLoaderPath;
@@ -50,7 +51,7 @@ internal static unsafe class GraphicalVulkanLoader
 
             string? previousDriverFiles = Environment.GetEnvironmentVariable(
                 DriverFilesEnvironmentVariable);
-            Environment.SetEnvironmentVariable(
+            PublishEnvironmentVariable(
                 DriverFilesEnvironmentVariable,
                 layout.DriverManifestPath);
 
@@ -84,11 +85,40 @@ internal static unsafe class GraphicalVulkanLoader
             catch
             {
                 NativeLibrary.Free(loaderHandle);
-                Environment.SetEnvironmentVariable(
-                    DriverFilesEnvironmentVariable,
-                    previousDriverFiles);
+                try
+                {
+                    PublishEnvironmentVariable(
+                        DriverFilesEnvironmentVariable,
+                        previousDriverFiles);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The failure that brought us here is the one worth reporting.
+                }
+
                 throw;
             }
+        }
+    }
+
+    internal static void PublishEnvironmentVariable(string name, string? value)
+    {
+        // .NET's copy of the environment is not the one the native loader reads.
+        Environment.SetEnvironmentVariable(name, value);
+        if (value is null)
+        {
+            if (Unsetenv(name) != NativeEnvironmentCallSuccess)
+            {
+                throw new InvalidOperationException(
+                    $"Could not clear '{name}' from the native environment " +
+                    $"(errno {Marshal.GetLastPInvokeError()}).");
+            }
+        }
+        else if (Setenv(name, value, overwrite: 1) != NativeEnvironmentCallSuccess)
+        {
+            throw new InvalidOperationException(
+                $"Could not publish '{name}' to the native environment " +
+                $"(errno {Marshal.GetLastPInvokeError()}).");
         }
     }
 
@@ -155,4 +185,18 @@ internal static unsafe class GraphicalVulkanLoader
 
         return layout;
     }
+
+    [LibraryImport(
+        "libSystem.dylib",
+        EntryPoint = "setenv",
+        StringMarshalling = StringMarshalling.Utf8,
+        SetLastError = true)]
+    private static partial int Setenv(string name, string value, int overwrite);
+
+    [LibraryImport(
+        "libSystem.dylib",
+        EntryPoint = "unsetenv",
+        StringMarshalling = StringMarshalling.Utf8,
+        SetLastError = true)]
+    private static partial int Unsetenv(string name);
 }

--- a/tests/AcDream.App.Tests/Platform/GraphicalVulkanLoaderTests.cs
+++ b/tests/AcDream.App.Tests/Platform/GraphicalVulkanLoaderTests.cs
@@ -1,8 +1,9 @@
+using System.Runtime.InteropServices;
 using AcDream.App.Platform;
 
 namespace AcDream.App.Tests.Platform;
 
-public sealed class GraphicalVulkanLoaderTests
+public sealed partial class GraphicalVulkanLoaderTests
 {
     [Fact]
     public void MissingPackagedRuntimeRetainsSystemFallback()
@@ -74,5 +75,67 @@ public sealed class GraphicalVulkanLoaderTests
 
         Assert.Contains("libMoltenVK.dylib", error.Message);
         Assert.Contains("MoltenVK_icd.json", error.Message);
+    }
+
+    [Fact]
+    [Trait("Lane", "MacOS")]
+    public void PublishedEnvironmentVariableIsVisibleToNativeGetenv()
+    {
+        if (!OperatingSystem.IsMacOS())
+            throw new PlatformNotSupportedException("Lane=MacOS requires a native macOS host.");
+
+        string name = "ACDREAM_TEST_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            GraphicalVulkanLoader.PublishEnvironmentVariable(name, "/tmp/probe");
+
+            string? native = Marshal.PtrToStringUTF8(Getenv(name));
+
+            Assert.Equal("/tmp/probe", native);
+
+            GraphicalVulkanLoader.PublishEnvironmentVariable(name, "/tmp/probe-2");
+
+            Assert.Equal("/tmp/probe-2", Marshal.PtrToStringUTF8(Getenv(name)));
+
+            GraphicalVulkanLoader.PublishEnvironmentVariable(name, null);
+
+            Assert.Equal(nint.Zero, Getenv(name));
+        }
+        finally
+        {
+            GraphicalVulkanLoader.PublishEnvironmentVariable(name, null);
+        }
+    }
+
+    [Fact]
+    public void EnvironmentSetEnvironmentVariableOnlyAppearsInsidePublishEnvironmentVariable()
+    {
+        string source = File.ReadAllText(Path.Combine(
+            RepositoryRoot(),
+            "src",
+            "AcDream.App",
+            "Platform",
+            "GraphicalVulkanLoader.cs"));
+
+        int occurrences = source.Split(
+            "Environment.SetEnvironmentVariable",
+            StringSplitOptions.None).Length - 1;
+
+        Assert.True(
+            occurrences == 1,
+            "Environment.SetEnvironmentVariable must appear exactly once, " +
+            "inside PublishEnvironmentVariable; route all other callers through it.");
+    }
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "getenv", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint Getenv(string name);
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "AcDream.slnx")))
+            directory = directory.Parent;
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root.");
     }
 }


### PR DESCRIPTION
The client does not start on a Mac without a system-wide MoltenVK. It exits before a window appears with `vkCreateInstance returned ErrorIncompatibleDriver`. Fixes #55.

`GraphicalVulkanLoader` publishes the bundled ICD manifest in `VK_DRIVER_FILES` with `Environment.SetEnvironmentVariable`. On Unix that only updates .NET's copy of the environment and never calls `setenv`, so the loader, which reads it with `getenv`, falls back to a default search that does not include `Resources/vulkan/icd.d`. Homebrew's `molten-vk` installs its manifest into that search path, which is why it works on a developer's Mac.

The publish now calls `setenv` as well, and `unsetenv` to clear. I kept `VK_DRIVER_FILES` over `VK_ADD_DRIVER_FILES`, because the append form makes a Mac with a system MoltenVK enumerate the same GPU twice.

One test checks the value reaches native `getenv`; a source check keeps the publish going through the helper. The first needs a Mac, and `macos-portable` picks App tests by class name, so I added a line to that job for `GraphicalVulkanLoaderTests`. Happy to drop it; the source check also runs in `windows-gate`.

On a MacBook Air M3, macOS 26.6.2, with no system MoltenVK, the 0.1.3 client and then this branch's packaged client:

```
[Vulkan Loader] ERROR | DRIVER: vkCreateInstance: Found no drivers!
```

```
vulkan: capability gate passed (Cocoa, Apple M3, Vulkan 1.3.357, vendor 0x106B, device 0x1A060209, driver 0.2.2210 (raw 0x000028A2)); ...
```

The fixed client went on into the world. I ran it directly, not through a launcher install that I can't mint. As soon as this is merged into a new build I will re-test.

Green on all three platforms in my fork's CI, the same hosted images this repo's pull request lane uses: windows-latest, ubuntu-latest and macos-14 (shaneedwards/OpenAC#7).