### PR TITLE
build: add Linux-friendly local build helper

### DIFF
--- a/docs/building-and-running.md
+++ b/docs/building-and-running.md
@@ -34,6 +34,13 @@ The filter is the portable gate described in `release-gate.md`. Tests behind a
 `Lane` need a specific resource; run them when you have it, for example
 `--filter "Lane=Vulkan"` on a machine with a GPU.
 
+On Linux, `bash tools/build-linux.sh` runs the Release build with .NET and
+NuGet state isolated under
+`XDG_CACHE_HOME` (or `/tmp`). This is useful in containers and CI workers with
+a read-only home directory. It redirects generated package locks to that cache
+so local restores do not rewrite tracked package-lock files. Pass `--test` to
+run the portable test filter afterward.
+
 ## Prepare the content package
 
 Rendering and collision read a validated prepared package instead of decoding

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,6 +5,7 @@
 | `ShaderCompiler/` | .NET shader compiler over Silk.NET.Shaderc used by `compile-shaders.ps1`. Part of `AcDream.slnx`. |
 | `RenderPackValidator/` | Validates a render pack against the SDK contract. Part of `AcDream.slnx`; `tests/AcDream.RenderPackValidator.Tests` covers it. |
 | `compile-shaders.ps1` | Recompiles every GLSL source to the committed SPIR-V and rewrites the freshness manifest. |
+| `build-linux.sh` | Linux-friendly Release build. Keeps .NET, NuGet, MSBuild, and generated lock state outside the checkout; pass `--test` for the portable test filter. |
 | `run-release-gate.ps1` | The complete bounded local test gate: locked restore, Release build, every test assembly in its own timed process, TRX and hash evidence under `artifacts/release-gate/`. Its default `-TestFilter` is the portable filter CI copies. |
 | `publish-bin.ps1` | Builds the self-contained client and launcher payloads and `manifest.json`. CI runs it in the release job; locally it is for inspection. |
 | `update-package-locks.ps1` | Regenerates every neutral and RID NuGet lock file after a dependency change. |

--- a/tools/build-linux.sh
+++ b/tools/build-linux.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Restore and build OpenAC on Linux without requiring a writable home directory.
+#
+# Usage:
+#   bash tools/build-linux.sh [--test]
+#
+# The cache locations may be overridden by the environment. They deliberately
+# live outside the checkout so a restore cannot modify tracked lock files.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache_root="${XDG_CACHE_HOME:-/tmp}/openac-dotnet"
+
+export DOTNET_CLI_HOME="${DOTNET_CLI_HOME:-$cache_root/cli}"
+export NUGET_PACKAGES="${NUGET_PACKAGES:-$cache_root/packages}"
+export NUGET_HTTP_CACHE_PATH="${NUGET_HTTP_CACHE_PATH:-$cache_root/http}"
+export MSBuildUserExtensionsPath="${MSBuildUserExtensionsPath:-$cache_root/msbuild}"
+export DOTNET_CLI_TELEMETRY_OPTOUT="${DOTNET_CLI_TELEMETRY_OPTOUT:-1}"
+export DOTNET_NOLOGO="${DOTNET_NOLOGO:-1}"
+
+test_after_build=false
+if [[ "${1:-}" == "--test" ]]; then
+    test_after_build=true
+elif [[ $# -ne 0 ]]; then
+    echo "Usage: bash tools/build-linux.sh [--test]" >&2
+    exit 64
+fi
+
+cd "$repo_root"
+dotnet --version
+# Keep generated lock files outside the checkout. The lock-update script owns
+# the committed neutral and RID-specific files.
+mkdir -p "$cache_root/locks"
+lock_path="$cache_root/locks/\$(MSBuildProjectName).lock.json"
+dotnet restore AcDream.slnx "-p:NuGetLockFilePath=$lock_path"
+dotnet build AcDream.slnx -c Release --no-restore -p:CoDeployBakeToolOnBuild=false
+
+if [[ "$test_after_build" == true ]]; then
+    dotnet test AcDream.slnx -c Release --no-build --no-restore \
+        --filter 'Lane!=InstalledDat&Lane!=PreparedPackage&Lane!=Live&Lane!=Manual&Lane!=Timing&Lane!=Windows&Lane!=Linux&Lane!=MacOS&Lane!=Unix&Lane!=Vulkan&Lane!=SystemFont&Purpose!=Diagnostic&Status!=KnownFailure'
+fi


### PR DESCRIPTION
## What this changes
Adds tools/build-linux.sh for Linux builds in containers or environments with a read-only home directory. The helper redirects .NET, NuGet, MSBuild, and generated lock-file state to a cache directory outside the checkout, then restores and builds the solution; --test also runs the portable test filter.

Documents the helper in the build guide and tools reference. Windows behavior and existing CI workflows remain unchanged.

Found three tests that does not work. Fixes coming in another PR.

## Checklist
- [X] `dotnet build AcDream.slnx -c Release` is green
- [ ] The portable test filter passes locally (see CONTRIBUTING.md)
- [X] One topic per PR
- [X] No code copied from ACEmulator, ACViewer, or holtburger
- [X] No comments describing the original client's internals
