### PR TITLE
test: stabilize portable App test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ version:
 git clone https://github.com/eriknihlen/OpenAC.git
 cd OpenAC
 dotnet build AcDream.slnx -c Release
-dotnet test AcDream.slnx -c Release --no-build --filter "Lane!=InstalledDat&Lane!=PreparedPackage&Lane!=Live&Lane!=Manual&Lane!=Timing&Lane!=Windows&Lane!=Linux&Lane!=Vulkan&Lane!=SystemFont&Purpose!=Diagnostic&Status!=KnownFailure"
+dotnet test AcDream.slnx -c Release --no-build --filter "Lane!=InstalledDat&Lane!=PreparedPackage&Lane!=Live&Lane!=Manual&Lane!=Timing&Lane!=Windows&Lane!=Linux&Lane!=MacOS&Lane!=Unix&Lane!=Vulkan&Lane!=SystemFont&Purpose!=Diagnostic&Status!=KnownFailure"
 ```
 
 That filter is the portable gate: it skips tests that need your retail data

--- a/tests/AcDream.App.Tests/Rendering/SilkWindowCallbackBindingTests.cs
+++ b/tests/AcDream.App.Tests/Rendering/SilkWindowCallbackBindingTests.cs
@@ -412,14 +412,22 @@ public sealed class SilkWindowCallbackBindingTests
             pacing,
             gate);
 
-        Task<Exception> first = Task.Run(() => Record.Exception(binding.Attach));
+        Task<Exception> first = Task.Factory.StartNew(
+            () => Record.Exception(binding.Attach),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         Assert.True(surface.AddEntered.Wait(TimeSpan.FromSeconds(5)));
         using var secondStarted = new ManualResetEventSlim(false);
-        Task<Exception> second = Task.Run(() =>
-        {
-            secondStarted.Set();
-            return Record.Exception(binding.Attach);
-        });
+        Task<Exception> second = Task.Factory.StartNew(
+            () =>
+            {
+                secondStarted.Set();
+                return Record.Exception(binding.Attach);
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         Assert.True(secondStarted.Wait(TimeSpan.FromSeconds(5)));
         Exception secondError = await second.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.IsType<InvalidOperationException>(secondError);

--- a/tests/AcDream.App.Tests/Streaming/LandblockConcretePresentationPipelineTests.cs
+++ b/tests/AcDream.App.Tests/Streaming/LandblockConcretePresentationPipelineTests.cs
@@ -198,7 +198,10 @@ public sealed class LandblockConcretePresentationPipelineTests
             maxGpuUploadBytes: 1_000_000,
             maxGlRetireOperations: 64,
             destinationReserveFraction: 0.75f);
-        var meter = new StreamingWorkMeter(budget);
+        var meter = new StreamingWorkMeter(
+            budget,
+            timestamp: static () => 0,
+            timestampFrequency: 1);
 
         LandblockPublicationAdvance advance = pipeline.PublishLoaded(
             result,


### PR DESCRIPTION
## What this changes
Aligns the contributor portable-test command with the canonical cross-platform filter so macOS- and Unix-specific tests are not run on unsupported hosts.

Makes two App tests deterministic under parallel suite execution by using a fixed streaming-work clock and dedicated long-running threads for deliberately blocked callback attachment. No production behavior changes.

## Checklist
- [X] `dotnet build AcDream.slnx -c Release` is green
- [X] The portable test filter passes locally (see CONTRIBUTING.md)
- [X] One topic per PR
- [X] No code copied from ACEmulator, ACViewer, or holtburger
- [X] No comments describing the original client's internals
