### PR TITLE
Guard PublishEnvironmentVariable to macOS

### DIFF
--- a/src/AcDream.App/Platform/GraphicalVulkanLoader.cs
+++ b/src/AcDream.App/Platform/GraphicalVulkanLoader.cs
@@ -103,6 +103,12 @@ internal static unsafe partial class GraphicalVulkanLoader
 
     internal static void PublishEnvironmentVariable(string name, string? value)
     {
+        if (!OperatingSystem.IsMacOS())
+        {
+            throw new PlatformNotSupportedException(
+                "Publishing to the native environment requires macOS.");
+        }
+
         // .NET's copy of the environment is not the one the native loader reads.
         Environment.SetEnvironmentVariable(name, value);
         if (value is null)

--- a/tests/AcDream.App.Tests/Platform/GraphicalVulkanLoaderTests.cs
+++ b/tests/AcDream.App.Tests/Platform/GraphicalVulkanLoaderTests.cs
@@ -127,6 +127,30 @@ public sealed partial class GraphicalVulkanLoaderTests
             "inside PublishEnvironmentVariable; route all other callers through it.");
     }
 
+    [Fact]
+    public void PublishEnvironmentVariableRequiresMacOS()
+    {
+        string name = "ACDREAM_TEST_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            if (OperatingSystem.IsMacOS())
+            {
+                GraphicalVulkanLoader.PublishEnvironmentVariable(name, null);
+            }
+            else
+            {
+                Assert.Throws<PlatformNotSupportedException>(
+                    () => GraphicalVulkanLoader.PublishEnvironmentVariable(name, "/tmp/probe"));
+            }
+
+            Assert.Null(Environment.GetEnvironmentVariable(name));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
     [LibraryImport("libSystem.dylib", EntryPoint = "getenv", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint Getenv(string name);
 


### PR DESCRIPTION
Follow-up to #56, as asked in #57. Fixes #57.

`PublishEnvironmentVariable` now throws `PlatformNotSupportedException` off macOS, the same guard `MacMonotonicFramePacingWaiter.Create()` uses. It runs before the managed write, so a refused call leaves both environments untouched. I kept the name, since the guard already makes the limit explicit.

The test has no lane so that it runs where the guard matters: off macOS it asserts that exact exception, and on macOS that a clear passes through. `windows-gate` runs the refusal (the release gate uses the same filter), and `macos-portable` picks the test up with the rest of `GraphicalVulkanLoaderTests`. xunit here cannot skip at runtime, so the test branches on the OS.

I checked that it fails without the guard. With only the test pushed, `windows-gate` in my fork went red:

```
  Failed AcDream.App.Tests.Platform.GraphicalVulkanLoaderTests.PublishEnvironmentVariableRequiresMacOS [16 ms]
   Assert.Throws() Failure: Exception type was not an exact match
Expected: typeof(System.PlatformNotSupportedException)
Actual:   typeof(System.DllNotFoundException)
```

With the guard it is green on all three platforms in my fork's CI, the same hosted images this repo's pull request lane uses: windows-latest, ubuntu-latest and macos-14. The Linux job does not run `AcDream.App.Tests`, so nothing has run this test on Linux.

On macOS the guard is a pass-through: locally the whole `GraphicalVulkanLoaderTests` class passes, including the native `setenv` test.